### PR TITLE
fix(typo): from "mongoServer" to "mongod"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const mongod = new MongodbMemoryServer();
 const uri = await mongod.getConnectionString();
 const port = await mongod.getPort();
 const dbPath = await mongod.getDbPath();
-const dbName = await mongoServer.getDbName();
+const dbName = await mongod.getDbName();
 
 // some code
 


### PR DESCRIPTION
Sometimes you use the name `mongoServer` and other `mongod` to represent an instance of MongodbMemoryServer.

How could we improve the consistency of documentation?

> PS.: mongod remembers me mongo-daemon :smile: