### PR TITLE
fix(MongoBinaryDownloadUrl): removed `ssl` from options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ const mongod = new MongodbMemoryServer({
     downloadDir?: string, // by default %HOME/.mongodb-binaries
     platform?: string, // by default os.platform()
     arch?: string, // by default os.arch()
-    ssl?: boolean, // by default false (use it if mongodb dist has only ssl version binary)
     debug?: boolean, // by default false
   },
   debug?: boolean, // by default false

--- a/src/MongoMemoryServer.js
+++ b/src/MongoMemoryServer.js
@@ -22,7 +22,6 @@ export type MongoMemoryServerOptsT = {
     downloadDir?: string,
     platform?: string,
     arch?: string,
-    ssl?: boolean,
     debug?: boolean | Function,
   },
   debug?: boolean,

--- a/src/util/MongoBinary.js
+++ b/src/util/MongoBinary.js
@@ -15,7 +15,6 @@ export type MongoBinaryOpts = {
   downloadDir?: string,
   platform?: string,
   arch?: string,
-  ssl?: boolean,
   debug?: boolean | Function,
 };
 
@@ -27,7 +26,6 @@ export default class MongoBinary {
       downloadDir = path.resolve(os.homedir(), '.mongodb-binaries'),
       platform = os.platform(),
       arch = os.arch(),
-      ssl = false,
       version = '3.4.4',
     } = opts;
 
@@ -79,7 +77,6 @@ export default class MongoBinary {
           downloadDir,
           platform,
           arch,
-          ssl,
           version,
         });
 

--- a/src/util/MongoBinaryDownload.js
+++ b/src/util/MongoBinaryDownload.js
@@ -15,7 +15,6 @@ export type MongoBinaryDownloadOpts = {
   downloadDir: string,
   platform: string,
   arch: string,
-  ssl: boolean,
   debug?: boolean | Function,
 };
 
@@ -32,21 +31,12 @@ export default class MongoBinaryDownload {
 
   downloadDir: string;
   arch: string;
-  ssl: boolean;
   version: string;
   platform: string;
 
-  constructor({
-    platform,
-    arch,
-    ssl,
-    downloadDir,
-    version,
-    debug,
-  }: $Shape<MongoBinaryDownloadOpts>) {
+  constructor({ platform, arch, downloadDir, version, debug }: $Shape<MongoBinaryDownloadOpts>) {
     this.platform = platform || os.platform();
     this.arch = arch || os.arch();
-    this.ssl = ssl || false;
     this.version = version || 'latest';
     this.downloadDir = path.resolve(downloadDir || 'mongodb-download');
     this.dlProgress = {
@@ -89,7 +79,6 @@ export default class MongoBinaryDownload {
     const mbdUrl = new MongoBinaryDownloadUrl({
       platform: this.platform,
       arch: this.arch,
-      ssl: this.ssl,
       version: this.version,
     });
 

--- a/src/util/MongoBinaryDownloadUrl.js
+++ b/src/util/MongoBinaryDownloadUrl.js
@@ -14,21 +14,18 @@ export type MongoBinaryDownloadUrlOpts = {
   version: string,
   platform: string,
   arch: string,
-  ssl?: boolean,
   os?: ?OS, // getos() result
 };
 
 export default class MongoBinaryDownloadUrl {
   platform: string;
   arch: string;
-  ssl: ?boolean;
   version: string;
   os: ?OS;
 
-  constructor({ platform, arch, ssl, version, os }: MongoBinaryDownloadUrlOpts) {
+  constructor({ platform, arch, version, os }: MongoBinaryDownloadUrlOpts) {
     this.platform = this.translatePlatform(platform);
     this.arch = this.translateArch(arch, this.platform);
-    this.ssl = ssl;
     this.version = version;
     this.os = os;
   }
@@ -50,6 +47,7 @@ export default class MongoBinaryDownloadUrl {
     }
   }
 
+  // https://www.mongodb.org/dl/win32
   async getArchiveNameWin(): Promise<string> {
     let name = `mongodb-${this.platform}`;
     name += `-${this.arch}`;
@@ -58,9 +56,16 @@ export default class MongoBinaryDownloadUrl {
     return name;
   }
 
+  // https://www.mongodb.org/dl/osx
   async getArchiveNameOsx(): Promise<string> {
     let name = `mongodb-osx`;
-    if (this.ssl) {
+    if (
+      !(
+        this.version.indexOf('3.0') === 0 ||
+        this.version.indexOf('2.') === 0 ||
+        this.version.indexOf('1.') === 0
+      )
+    ) {
       name += '-ssl';
     }
     name += `-${this.arch}`;
@@ -68,6 +73,7 @@ export default class MongoBinaryDownloadUrl {
     return name;
   }
 
+  // https://www.mongodb.org/dl/linux
   async getArchiveNameLinux(): Promise<string> {
     let name = `mongodb-linux`;
     name += `-${this.arch}`;

--- a/src/util/__tests__/MongoBinaryDownloadUrl-test.js
+++ b/src/util/__tests__/MongoBinaryDownloadUrl-test.js
@@ -5,38 +5,25 @@ import MongoBinaryDownloadUrl from '../MongoBinaryDownloadUrl';
 describe('MongoBinaryDownloadUrl', () => {
   describe('getDownloadUrl()', () => {
     describe('for mac', () => {
-      it('3.6.3 without ssl', async () => {
+      it('above 3.0', async () => {
         const du = new MongoBinaryDownloadUrl({
           platform: 'darwin',
           arch: 'x64',
           version: '3.6.3',
-        });
-        expect(await du.getDownloadUrl()).toBe(
-          'https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.6.3.tgz'
-        );
-      });
-
-      it('3.6.3 with ssl', async () => {
-        const du = new MongoBinaryDownloadUrl({
-          platform: 'darwin',
-          arch: 'x64',
-          version: '3.6.3',
-          ssl: true,
         });
         expect(await du.getDownloadUrl()).toBe(
           'https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz'
         );
       });
 
-      it('3.6.3 with ssl', async () => {
+      it('below and include 3.0', async () => {
         const du = new MongoBinaryDownloadUrl({
           platform: 'darwin',
           arch: 'x64',
-          version: '3.6.3',
-          ssl: true,
+          version: '3.0.0',
         });
         expect(await du.getDownloadUrl()).toBe(
-          'https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz'
+          'https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.0.0.tgz'
         );
       });
     });


### PR DESCRIPTION
Referenced to this [issue](https://github.com/nodkz/mongodb-memory-server/issues/55)
Now binaries for OSX older than 3.0 version is immediately installed with the SSL. Before and including 3.0 - without.

Since the SSL is not used anywhere else, it is completely removed from the code