### PR TITLE
Pass port as object to get-port

### DIFF
--- a/src/MongoMemoryServer.js
+++ b/src/MongoMemoryServer.js
@@ -109,7 +109,7 @@ export default class MongoMemoryServer {
     let tmpDir;
 
     const instOpts = this.opts.instance;
-    data.port = await getport(instOpts.port);
+    data.port = await getport({port: instOpts.port});
     this.debug = Debug(`Mongo[${data.port}]`);
     this.debug.enabled = !!this.opts.debug;
     data.dbName = await generateDbName(instOpts.dbName);

--- a/src/MongoMemoryServer.js
+++ b/src/MongoMemoryServer.js
@@ -109,7 +109,7 @@ export default class MongoMemoryServer {
     let tmpDir;
 
     const instOpts = this.opts.instance;
-    data.port = await getport({port: instOpts.port});
+    data.port = await getport({ port: instOpts.port });
     this.debug = Debug(`Mongo[${data.port}]`);
     this.debug.enabled = !!this.opts.debug;
     data.dbName = await generateDbName(instOpts.dbName);


### PR DESCRIPTION
According to `get-port` [docs](https://www.npmjs.com/package/get-port) preferred  port should be passed in as object.

Resolves #71 