### PR TITLE
chore(exports): Add MongoMemoryReplSet to package exports.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,7 @@
 import MongoBinary from './util/MongoBinary';
 import MongoInstance from './util/MongoInstance';
 import MongoMemoryServer from './MongoMemoryServer';
+import MongoMemoryReplSet from './MongoMemoryReplSet';
 
 export default MongoMemoryServer;
-export { MongoBinary, MongoInstance, MongoMemoryServer };
+export { MongoBinary, MongoInstance, MongoMemoryServer, MongoMemoryReplSet };

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,8 @@
 /* @flow */
-
+import MongoBinary from './util/MongoBinary';
+import MongoInstance from './util/MongoInstance';
 import MongoMemoryServer from './MongoMemoryServer';
 import MongoMemoryReplSet from './MongoMemoryReplSet';
-import MongoInstance from './util/MongoInstance';
-import MongoBinary from './util/MongoBinary';
 
 export default MongoMemoryServer;
-export { MongoMemoryServer, MongoMemoryReplSet, MongoInstance, MongoBinary };
+export { MongoBinary, MongoInstance, MongoMemoryServer, MongoMemoryReplSet };


### PR DESCRIPTION
Apparently I forgot to copy the export details from the flow version to the TypeScript definitions for the package's index file. Whoops!