### PR TITLE
clean up skipDownload code

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -13,9 +13,8 @@ function isModuleExists(name) {
   catch(e) { return false }
 }
 
-const skipDownload = typeof process.env.MONGOMS_DISABLE_POSTINSTALL === 'string'
-  ? ['1', 'on', 'yes', 'true'].indexOf(process.env.MONGOMS_DISABLE_POSTINSTALL.toLowerCase()) !== -1
-  : false;
+const skipDownload = (typeof process.env.MONGOMS_DISABLE_POSTINSTALL === 'string') &&
+  ['1', 'on', 'yes', 'true'].includes(process.env.MONGOMS_DISABLE_POSTINSTALL.toLowerCase())
 
 if (skipDownload) {
   console.log("Download is skipped by MONGOMS_DISABLE_POSTINSTALL variable");

--- a/postinstall.js
+++ b/postinstall.js
@@ -14,7 +14,7 @@ function isModuleExists(name) {
 }
 
 const skipDownload = (typeof process.env.MONGOMS_DISABLE_POSTINSTALL === 'string') &&
-  ['1', 'on', 'yes', 'true'].includes(process.env.MONGOMS_DISABLE_POSTINSTALL.toLowerCase())
+  (['1', 'on', 'yes', 'true'].indexOf(process.env.MONGOMS_DISABLE_POSTINSTALL.toLowerCase()) !== -1)
 
 if (skipDownload) {
   console.log("Download is skipped by MONGOMS_DISABLE_POSTINSTALL variable");


### PR DESCRIPTION
We were trying to figure out why this doesn't work (before 2.7.3 in the postinstall) and found this code confusing so I figured I'd contribute back and clean it up (thanks for the library!)