### PR TITLE
allow authorizations

### DIFF
--- a/src/util/MongoInstance.js
+++ b/src/util/MongoInstance.js
@@ -77,6 +77,7 @@ export default class MongodbInstance {
     if (storageEngine) result.push('--storageEngine', storageEngine);
     if (dbPath) result.push('--dbpath', dbPath);
     if (!auth) result.push('--noauth');
+    else if (auth) result.push('--auth');
     if (replSet) result.push('--replSet', replSet);
 
     return result.concat(args || []);

--- a/src/util/__tests__/MongoInstance-test.js
+++ b/src/util/__tests__/MongoInstance-test.js
@@ -73,6 +73,7 @@ describe('MongoInstance', () => {
       '27555',
       '--dbpath',
       '/data',
+      '--auth',
     ]);
   });
 


### PR DESCRIPTION
As referenced in [issue 111](https://github.com/nodkz/mongodb-memory-server/issues/111) PR 79 doesn't add auth to the command line arguments (prepareCommandArgs()) even when instance.auth is set to true.

This PR allows auth to be passed as a command line argument.


