### PR TITLE
add MONGOMS_SKIP_MD5_CHECK environment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ MONGOMS_VERSION=3
 MONGOMS_DEBUG=1 # also available case-insensitive values: "on" "yes" "true"
 MONGOMS_DOWNLOAD_MIRROR=url # your mirror url to download the mongodb binary
 MONGOMS_DISABLE_POSTINSTALL=1 # if you want to skip download binaries on `npm i` command
+MONGOMS_SKIP_MD5_CHECK=1 # if you want to skip MD5 check of downloaded binary
 ```
 
 ### Replica Set start:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ const mongod = new MongoMemoryServer({
     platform?: string, // by default os.platform()
     arch?: string, // by default os.arch()
     debug?: boolean, // by default false
+    skipMD5?: boolean, // by default false OR process.env.MONGOMS_SKIP_MD5_CHECK
   },
   debug?: boolean, // by default false
   autoStart?: boolean, // by default true
@@ -76,7 +77,8 @@ MONGOMS_VERSION=3
 MONGOMS_DEBUG=1 # also available case-insensitive values: "on" "yes" "true"
 MONGOMS_DOWNLOAD_MIRROR=url # your mirror url to download the mongodb binary
 MONGOMS_DISABLE_POSTINSTALL=1 # if you want to skip download binaries on `npm i` command
-MONGOMS_SKIP_MD5_CHECK=1 # if you want to skip MD5 check of downloaded binary
+MONGOMS_SKIP_MD5_CHECK=1 # if you want to skip MD5 check of downloaded binary.
+# Passed constructor parameter `binary.skipMD5` has higher priority.
 ```
 
 ### Replica Set start:

--- a/postinstall.js
+++ b/postinstall.js
@@ -27,6 +27,11 @@ if (isModuleExists('./lib/util/MongoBinary')) {
   console.log('mongodb-memory-server: checking MongoDB binaries cache...');
   MongoBinary.getPath({}).then(binPath => {
     console.log(`mongodb-memory-server: binary path is ${binPath}`);
+  })
+  .catch((err) => {
+    console.log(`failed to download/install MongoDB binaries. The error:
+${err}`)
+    process.exit(1)
   });
 } else {
   console.log("Can't resolve MongoBinary module");

--- a/src/util/MongoBinaryDownload.js
+++ b/src/util/MongoBinaryDownload.js
@@ -91,6 +91,14 @@ export default class MongoBinaryDownload {
   }
 
   async checkMd5(mongoDBArchiveMd5: string, mongoDBArchive: string) {
+    if (
+      typeof process.env.MONGOMS_SKIP_MD5_CHECK === 'string'
+        ? ['1', 'on', 'yes', 'true'].indexOf(process.env.MONGOMS_SKIP_MD5_CHECK.toLowerCase()) !==
+          -1
+        : false
+    ) {
+      return undefined;
+    }
     const signatureContent = fs.readFileSync(mongoDBArchiveMd5).toString('UTF-8');
     const m = signatureContent.match(/(.*?)\s/);
     const md5Remote = m ? m[1] : null;
@@ -98,6 +106,7 @@ export default class MongoBinaryDownload {
     if (md5Remote !== md5Local) {
       throw new Error('MongoBinaryDownload: md5 check is failed');
     }
+    return undefined;
   }
 
   async download(downloadUrl: string) {

--- a/src/util/MongoBinaryDownload.js
+++ b/src/util/MongoBinaryDownload.js
@@ -90,7 +90,7 @@ export default class MongoBinaryDownload {
     return mongoDBArchive;
   }
 
-  async checkMd5(mongoDBArchiveMd5: string, mongoDBArchive: string) {
+  async checkMd5(mongoDBArchiveMd5: string, mongoDBArchive: string): Promise<?boolean> {
     if (
       typeof process.env.MONGOMS_SKIP_MD5_CHECK === 'string'
         ? ['1', 'on', 'yes', 'true'].indexOf(process.env.MONGOMS_SKIP_MD5_CHECK.toLowerCase()) !==
@@ -106,7 +106,7 @@ export default class MongoBinaryDownload {
     if (md5Remote !== md5Local) {
       throw new Error('MongoBinaryDownload: md5 check is failed');
     }
-    return undefined;
+    return true;
   }
 
   async download(downloadUrl: string) {

--- a/src/util/MongoBinaryDownload.js
+++ b/src/util/MongoBinaryDownload.js
@@ -45,10 +45,8 @@ export default class MongoBinaryDownload {
     this.downloadDir = path.resolve(downloadDir || 'mongodb-download');
     if (skipMD5 === undefined) {
       this.skipMD5 =
-        typeof process.env.MONGOMS_SKIP_MD5_CHECK === 'string'
-          ? ['1', 'on', 'yes', 'true'].indexOf(process.env.MONGOMS_SKIP_MD5_CHECK.toLowerCase()) !==
-            -1
-          : false;
+        typeof process.env.MONGOMS_SKIP_MD5_CHECK === 'string' &&
+        ['1', 'on', 'yes', 'true'].indexOf(process.env.MONGOMS_SKIP_MD5_CHECK.toLowerCase()) !== -1;
     } else {
       this.skipMD5 = skipMD5;
     }
@@ -102,16 +100,16 @@ export default class MongoBinaryDownload {
     const downloadUrl = await mbdUrl.getDownloadUrl();
     const mongoDBArchive = await this.download(downloadUrl);
 
-    const mongoDBArchiveMd5 = await this.download(`${downloadUrl}.md5`);
-    await this.checkMd5(mongoDBArchiveMd5, mongoDBArchive);
+    await this.checkMD5(`${downloadUrl}.md5`, mongoDBArchive);
 
     return mongoDBArchive;
   }
 
-  async checkMd5(mongoDBArchiveMd5: string, mongoDBArchive: string): Promise<?boolean> {
+  async checkMD5(urlForReferenceMD5: string, mongoDBArchive: string): Promise<?boolean> {
     if (this.skipMD5) {
       return undefined;
     }
+    const mongoDBArchiveMd5 = await this.download(urlForReferenceMD5);
     const signatureContent = fs.readFileSync(mongoDBArchiveMd5).toString('UTF-8');
     const m = signatureContent.match(/(.*?)\s/);
     const md5Remote = m ? m[1] : null;

--- a/src/util/__tests__/MongoBinaryDownload-test.js
+++ b/src/util/__tests__/MongoBinaryDownload-test.js
@@ -56,7 +56,7 @@ MONGOMS_SKIP_MD5_CHECK environment variable`, () => {
     expect(callArg1.agent.options.href).toBe('http://user:pass@proxy:8080/');
   });
 
-  it(`checkMd5 returns true if md5 of downloaded mongoDBArchive is
+  it(`checkMD5 returns true if md5 of downloaded mongoDBArchive is
 the same as in the reference result`, () => {
     const someMd5 = 'md5';
     fs.readFileSync.mockImplementationOnce(() => `${someMd5} fileName`);
@@ -64,30 +64,36 @@ the same as in the reference result`, () => {
     const mongoDBArchivePath = '/some/path';
     const fileWithReferenceMd5 = '/another/path';
     const du = new MongoBinaryDownload({});
-    return du.checkMd5(fileWithReferenceMd5, mongoDBArchivePath).then(res => {
+    // $FlowFixMe
+    du.download = jest.fn(() => Promise.resolve(fileWithReferenceMd5));
+    const urlToMongoDBArchivePath = 'some-url';
+    return du.checkMD5(urlToMongoDBArchivePath, mongoDBArchivePath).then(res => {
       expect(res).toBe(true);
+      expect(du.download).toBeCalledWith(urlToMongoDBArchivePath);
       expect(fs.readFileSync).toBeCalledWith(fileWithReferenceMd5);
       expect(md5file.sync).toBeCalledWith(mongoDBArchivePath);
     });
   });
 
-  it(`checkMd5 throws an error if md5 of downloaded mongoDBArchive is NOT
+  it(`checkMD5 throws an error if md5 of downloaded mongoDBArchive is NOT
   the same as in the reference result`, () => {
     fs.readFileSync.mockImplementationOnce(() => 'someMd5 fileName');
     md5file.sync.mockImplementationOnce(() => 'anotherMd5');
     const du = new MongoBinaryDownload({});
-    expect(du.checkMd5('', '')).rejects.toMatchInlineSnapshot(
+    // $FlowFixMe
+    du.download = jest.fn(() => Promise.resolve(''));
+    expect(du.checkMD5('', '')).rejects.toMatchInlineSnapshot(
       `[Error: MongoBinaryDownload: md5 check is failed]`
     );
   });
 
-  it('true value of skipMD5 attribute disables checkMd5 validation', () => {
+  it('true value of skipMD5 attribute disables checkMD5 validation', () => {
     expect.assertions(1);
     fs.readFileSync.mockImplementationOnce(() => 'someMd5 fileName');
     md5file.sync.mockImplementationOnce(() => 'anotherMd5');
     const du = new MongoBinaryDownload({});
     du.skipMD5 = true;
-    return du.checkMd5('', '').then(res => {
+    return du.checkMD5('', '').then(res => {
       expect(res).toBe(undefined);
     });
   });


### PR DESCRIPTION
There are several changes in this pull request:
- add error handling in postinstall.js script for verbose error during downloading and installation
- add MONGOMS_SKIP_MD5_CHECK environment variable for skipping MD5 check with the reference result

FYI: md5 sum has been updated in the MongoDB mirror, so I removed my workaround in MongoBinary-test.js. Even this pull request currently isn't required, I think it's good to have such option for the future.