### PR TITLE
fix: promisfy fs.access in getSystemPath

### DIFF
--- a/src/util/MongoBinary.js
+++ b/src/util/MongoBinary.js
@@ -8,6 +8,7 @@ import mkdirp from 'mkdirp';
 import findCacheDir from 'find-cache-dir';
 import { execSync } from 'child_process';
 import dedent from 'dedent';
+import { promisify } from 'util';
 import MongoBinaryDownload from './MongoBinaryDownload';
 
 export type MongoBinaryCache = {
@@ -30,12 +31,12 @@ export default class MongoBinary {
     let binaryPath: string = '';
 
     try {
-      await fs.access(systemBinary);
+      await promisify(fs.access)(systemBinary);
 
       this.debug(`MongoBinary: found sytem binary path at ${systemBinary}`);
       binaryPath = systemBinary;
     } catch (err) {
-      this.debug(`MongoBinary: can't find system binary at ${systemBinary}`);
+      this.debug(`MongoBinary: can't find system binary at ${systemBinary}. ${err.message}`);
     }
 
     return binaryPath;

--- a/src/util/__tests__/MongoBinary-test.js
+++ b/src/util/__tests__/MongoBinary-test.js
@@ -39,7 +39,7 @@ describe('MongoBinary', () => {
       process.env.MONGOMS_SYSTEM_BINARY = '/usr/local/bin/mongod';
       await MongoBinary.getPath();
 
-      expect(accessSpy).toHaveBeenCalledWith('/usr/local/bin/mongod');
+      expect(accessSpy).toHaveBeenCalledWith('/usr/local/bin/mongod', expect.any(Function));
 
       accessSpy.mockClear();
     });
@@ -81,7 +81,7 @@ describe('MongoBinary', () => {
       const accessSpy = jest.spyOn(fs, 'access');
       await MongoBinary.getSystemPath('/usr/bin/mongod');
 
-      expect(accessSpy).toHaveBeenCalledWith('/usr/bin/mongod');
+      expect(accessSpy).toHaveBeenCalledWith('/usr/bin/mongod', expect.any(Function));
 
       accessSpy.mockClear();
     });


### PR DESCRIPTION
Trying to use the MongoBinary on my alpine container and ran into an issue where it can't find the binary file i pass in even though the binary exists.  Trace down the problem and is seem to be related to fs.access() throwing the error where callback is not defined.  fs.access is not a promise so we need to promisify for the code to work. 