### PR TITLE
fix(MongoInstance): kill the `killlerProcess` on instance kill

### DIFF
--- a/src/util/MongoInstance.js
+++ b/src/util/MongoInstance.js
@@ -111,6 +111,12 @@ export default class MongodbInstance {
         this.childProcess.kill();
       });
     }
+    if (this.killerProcess && !(this.killerProcess: any).killed) {
+      await new Promise(resolve => {
+        this.killerProcess.once(`exit`, resolve);
+        this.killerProcess.kill();
+      });
+    }
     return this;
   }
 

--- a/src/util/__tests__/MongoInstance-test.js
+++ b/src/util/__tests__/MongoInstance-test.js
@@ -124,7 +124,9 @@ describe('MongoInstance', () => {
       binary: { version: 'latest' },
     });
     const pid: any = mongod.getPid();
+    const killerPid: any = mongod.killerProcess.pid;
     expect(pid).toBeGreaterThan(0);
+    expect(killerPid).toBeGreaterThan(0);
 
     function isPidRunning(p: number) {
       try {
@@ -135,8 +137,10 @@ describe('MongoInstance', () => {
     }
 
     expect(isPidRunning(pid)).toBeTruthy();
+    expect(isPidRunning(killerPid)).toBeTruthy();
     await mongod.kill();
     expect(isPidRunning(pid)).toBeFalsy();
+    expect(isPidRunning(killerPid)).toBeFalsy();
   });
 
   it('should work with mongodb 4.0.3', async () => {


### PR DESCRIPTION
When a `MongoInstance` is killed, the `killerProcess` should also be killed. Else `jest` may fail in other projects, since there remains an `open handle` for the `killerProcess` until the interval (2s)  is called, see  [Mongo Killer Interval](https://github.com/nodkz/mongodb-memory-server/blob/b59ed826dd4f3cd31ad6f05c890f70eaad034abd/src/util/mongo_killer.js#L32).