### PR TITLE
Fix #136 - Fix MD5 check failing due to validating minimum size for MD5 file itself

### DIFF
--- a/src/util/MongoBinary.d.ts
+++ b/src/util/MongoBinary.d.ts
@@ -10,6 +10,7 @@ export interface MongoBinaryOpts {
   platform?: string;
   arch?: string;
   debug?: DebugPropT;
+  checkMD5?: boolean;
 }
 
 // disable error for a class with all static functions,

--- a/src/util/MongoBinaryDownload.js
+++ b/src/util/MongoBinaryDownload.js
@@ -223,7 +223,7 @@ export default class MongoBinaryDownload {
         response.pipe(fileStream);
 
         fileStream.on('finish', () => {
-          if (this.dlProgress.current < 1000000) {
+          if (this.dlProgress.current < 1000000 && !httpOptions.path.endsWith('.md5')) {
             const downloadUrl =
               this._downloadingUrl || `https://${httpOptions.hostname}/${httpOptions.path}`;
             reject(


### PR DESCRIPTION
Also,

- Fix TS typings to accept documented `binary.checkMD5` flag.