### PR TITLE
Pass instance ip option to MongoInstance.run

### DIFF
--- a/src/MongoMemoryServer.js
+++ b/src/MongoMemoryServer.js
@@ -133,6 +133,7 @@ export default class MongoMemoryServer {
         replSet: data.replSet,
         args: this.opts.instance.args,
         auth: this.opts.instance.auth,
+        ip: this.opts.instance.ip
       },
       binary: this.opts.binary,
       spawn: this.opts.spawn,

--- a/src/MongoMemoryServer.js
+++ b/src/MongoMemoryServer.js
@@ -133,7 +133,7 @@ export default class MongoMemoryServer {
         replSet: data.replSet,
         args: this.opts.instance.args,
         auth: this.opts.instance.auth,
-        ip: this.opts.instance.ip
+        ip: this.opts.instance.ip,
       },
       binary: this.opts.binary,
       spawn: this.opts.spawn,


### PR DESCRIPTION
I was running into an issue where I was trying to set the `ip` option but the mongod command that was spawned still had '127.0.0.1' in it. I believe the option is never actually being passed in.