### PR TITLE
Support for replSetInitiate settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ to be promoted to Primary before the replica set can be successfully used but th
 (see [electionTimeoutMillis](https://docs.mongodb.com/manual/reference/replica-configuration/#rsconf.settings.electionTimeoutMillis)).
 
 It is possible to force the replica set to elect a node as Primary before the default 10 seconds by changing the `electionTimeoutMillis`
-parameters like shown below:
+parameter as shown below:
 
 ```js
 const replSet = new MongoMemoryReplSet({

--- a/README.md
+++ b/README.md
@@ -146,9 +146,34 @@ const replSet = new MongoMemoryReplSet({
     oplogSize, // size (in MB) for the oplog; (default: 1)
     spawn, // spawn options when creating the child processes
     storageEngine, // default storage engine for instance. (Can be overridden per instance)
+    configSettings: { // Optional settings for replSetInitiate command. See https://docs.mongodb.com/manual/reference/command/replSetInitiate/
+        chainingAllowed: boolean, // When true it allows secondary members to replicate from other secondary members. When false, secondaries can replicate only from the primary.
+        heartbeatTimeoutSecs: number, // Number of seconds that the replica set members wait for a successful heartbeat from each other. If a member does not respond in time, other members mark the delinquent member as inaccessible.
+        heartbeatIntervalMillis: number, // The frequency in milliseconds of the heartbeats.
+        electionTimeoutMillis: number, // The time limit in milliseconds for detecting when a replica set’s primary is unreachable.
+        catchUpTimeoutMillis: number, // Time limit for a newly elected primary to sync (catch up) with the other replica set members that may have more recent writes.
+    }
   },
 });
 ```
+
+The `replSet.configSettings` can be used to tune the initialization of the replica set. By default one of the nodes has 
+to be promoted to Primary before the replica set can be successfully used but that happens only after a timeout of 10 seconds
+(see [electionTimeoutMillis](https://docs.mongodb.com/manual/reference/replica-configuration/#rsconf.settings.electionTimeoutMillis)).
+
+It is possible to force the replica set to elect a node as Primary before the default 10 seconds by changing the `electionTimeoutMillis`
+parameters like shown below:
+
+```js
+const replSet = new MongoMemoryReplSet({
+    replSet: {
+        configSettings: {
+            electionTimeoutMillis: 100,
+        },
+    },
+})
+await replSet.waitUntilRunning()
+``` 
 
 ### Simple test with MongoClient
 

--- a/src/MongoMemoryReplSet.ts
+++ b/src/MongoMemoryReplSet.ts
@@ -35,6 +35,15 @@ export interface ReplSetOpts {
   oplogSize: number;
   spawn: SpawnOptions;
   storageEngine: StorageEngineT;
+  configSettings?: MongoMemoryReplSetConfigSettingsT;
+}
+
+export interface MongoMemoryReplSetConfigSettingsT {
+  chainingAllowed?: boolean;
+  heartbeatTimeoutSecs?: number;
+  heartbeatIntervalMillis?: number;
+  electionTimeoutMillis?: number;
+  catchUpTimeoutMillis?: number;
 }
 
 export interface MongoMemoryReplSetOptsT {
@@ -215,6 +224,7 @@ export default class MongoMemoryReplSet extends EventEmitter {
       const rsConfig = {
         _id: this.opts.replSet.name,
         members,
+        settings: this.opts.replSet.configSettings || {},
       };
       await this.admin.command({ replSetInitiate: rsConfig });
       this.debug('Waiting for replica set to have a PRIMARY member.');


### PR DESCRIPTION
Here's a Pull Request to allow additional settings when initializing a replica set:

```js
const replSet = new MongoMemoryReplSet({
    replSet: {
        configSettings: {
            electionTimeoutMillis: 100,
        },
    },
})
await replSet.waitUntilRunning()
```