### PR TITLE
feat(install): configure installation from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ const mongod = new MongoMemoryServer({
 });
 ```
 
-Also you can use the environment variables for configure installation process
+You can also use the environment variables or package.json's `config` section to configure installation process.
+Environment variables have higher priority than contents of package.json.
 
 ```txt
 MONGOMS_DOWNLOAD_DIR=/path/to/mongodb/binaries
@@ -96,6 +97,22 @@ MONGOMS_DISABLE_POSTINSTALL=1 # if you want to skip download binaries on `npm i`
 MONGOMS_SYSTEM_BINARY=/usr/local/bin/mongod # if you want to use an existing binary already on your system.
 MONGOMS_MD5_CHECK=1 # if you want to make MD5 check of downloaded binary.
 # Passed constructor parameter `binary.checkMD5` has higher priority.
+```
+
+```json
+"config": {
+  "mongoDbMemoryServer": {
+    "downloadDir": "/path/to/mongodb/binaries",
+    "platform": "linux",
+    "arch": "x64",
+    "version": "3",
+    "debug": "1",
+    "downloadMirror": "url",
+    "disablePostinstall": "1",
+    "systemBinary": "/usr/local/bin/mongod",
+    "md5Check": "1"
+  }
+}
 ```
 
 ### Replica Set start:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/decompress": "^4.2.3",
     "@types/dedent": "^0.7.0",
     "@types/find-cache-dir": "^2.0.0",
+    "@types/find-package-json": "^1.1.0",
     "@types/get-port": "^4.0.1",
     "@types/getos": "^3.0.0",
     "@types/jest": "^24.0.11",
@@ -54,10 +55,12 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
+    "camelcase": "^5.3.1",
     "debug": "^4.1.1",
     "decompress": "^4.2.0",
     "dedent": "^0.7.0",
     "find-cache-dir": "^2.0.0",
+    "find-package-json": "^1.2.0",
     "get-port": "^4.2.0",
     "getos": "^3.1.1",
     "https-proxy-agent": "^2.2.1",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -16,9 +16,16 @@ function isModuleExists(name) {
   }
 }
 
+if (!isModuleExists('../lib/util/resolve-config')) {
+  console.log('Could not resolve postinstall configuration');
+  return;
+}
+const resolveConfig = require('../lib/util/resolve-config').default;
+
+const envDisablePostinstall = resolveConfig('DISABLE_POSTINSTALL');
 const skipDownload =
-  typeof process.env.MONGOMS_DISABLE_POSTINSTALL === 'string' &&
-  ['1', 'on', 'yes', 'true'].indexOf(process.env.MONGOMS_DISABLE_POSTINSTALL.toLowerCase()) !== -1;
+  typeof envDisablePostinstall === 'string' &&
+  ['1', 'on', 'yes', 'true'].indexOf(envDisablePostinstall.toLowerCase()) !== -1;
 
 if (skipDownload) {
   console.log('Download is skipped by MONGOMS_DISABLE_POSTINSTALL variable');

--- a/src/util/MongoBinary.ts
+++ b/src/util/MongoBinary.ts
@@ -9,6 +9,7 @@ import dedent from 'dedent';
 import { promisify } from 'util';
 import MongoBinaryDownload from './MongoBinaryDownload';
 import { DebugFn } from '../types';
+import resolveConfig from './resolve-config';
 
 // TODO: return back `latest` version when it will be fixed in MongoDB distro (for now use 4.0.3 😂)
 // More details in https://github.com/nodkz/mongodb-memory-server/issues/131
@@ -103,9 +104,10 @@ export default class MongoBinary {
 
   static async getPath(opts: MongoBinaryOpts = {}): Promise<string> {
     const legacyDLDir = path.resolve(os.homedir(), '.mongodb-binaries');
+    const envDebug = resolveConfig('DEBUG');
     const defaultOptions = {
       downloadDir:
-        process.env.MONGOMS_DOWNLOAD_DIR ||
+        resolveConfig('DOWNLOAD_DIR') ||
         (fs.existsSync(legacyDLDir)
           ? legacyDLDir
           : path.resolve(
@@ -118,13 +120,13 @@ export default class MongoBinary {
               }) || '',
               'mongodb-binaries'
             )),
-      platform: process.env.MONGOMS_PLATFORM || os.platform(),
-      arch: process.env.MONGOMS_ARCH || os.arch(),
-      version: process.env.MONGOMS_VERSION || LATEST_VERSION,
-      systemBinary: process.env.MONGOMS_SYSTEM_BINARY,
+      platform: resolveConfig('PLATFORM') || os.platform(),
+      arch: resolveConfig('ARCH') || os.arch(),
+      version: resolveConfig('VERSION') || LATEST_VERSION,
+      systemBinary: resolveConfig('SYSTEM_BINARY'),
       debug:
-        typeof process.env.MONGOMS_DEBUG === 'string'
-          ? ['1', 'on', 'yes', 'true'].indexOf(process.env.MONGOMS_DEBUG.toLowerCase()) !== -1
+        typeof envDebug === 'string'
+          ? ['1', 'on', 'yes', 'true'].indexOf(envDebug.toLowerCase()) !== -1
           : false,
     };
 

--- a/src/util/MongoBinaryDownload.ts
+++ b/src/util/MongoBinaryDownload.ts
@@ -9,6 +9,7 @@ import MongoBinaryDownloadUrl from './MongoBinaryDownloadUrl';
 import { DebugFn, DebugPropT, DownloadProgressT } from '../types';
 import { LATEST_VERSION } from './MongoBinary';
 import HttpsProxyAgent from 'https-proxy-agent';
+import resolveConfig from './resolve-config';
 
 export interface MongoBinaryDownloadOpts {
   version?: string;
@@ -43,10 +44,11 @@ export default class MongoBinaryDownload {
     this.arch = arch || os.arch();
     this.version = version || LATEST_VERSION;
     this.downloadDir = path.resolve(downloadDir || 'mongodb-download');
+    const envMd5Check = resolveConfig('MD5_CHECK');
     if (checkMD5 === undefined) {
       this.checkMD5 =
-        typeof process.env.MONGOMS_MD5_CHECK === 'string' &&
-        ['1', 'on', 'yes', 'true'].indexOf(process.env.MONGOMS_MD5_CHECK.toLowerCase()) !== -1;
+        typeof envMd5Check === 'string' &&
+        ['1', 'on', 'yes', 'true'].indexOf(envMd5Check.toLowerCase()) !== -1;
     } else {
       this.checkMD5 = checkMD5;
     }

--- a/src/util/MongoBinaryDownloadUrl.ts
+++ b/src/util/MongoBinaryDownloadUrl.ts
@@ -1,4 +1,5 @@
 import getos from 'getos';
+import resolveConfig from './resolve-config';
 
 export interface MongoBinaryDownloadUrlOpts {
   version: string;
@@ -22,7 +23,7 @@ export default class MongoBinaryDownloadUrl {
 
   async getDownloadUrl(): Promise<string> {
     const archive = await this.getArchiveName();
-    return `${process.env.MONGOMS_DOWNLOAD_MIRROR || 'https://fastdl.mongodb.org'}/${
+    return `${resolveConfig('DOWNLOAD_MIRROR') || 'https://fastdl.mongodb.org'}/${
       this.platform
     }/${archive}`;
   }

--- a/src/util/resolve-config.ts
+++ b/src/util/resolve-config.ts
@@ -1,0 +1,26 @@
+import camelCase from 'camelcase';
+import finder, { Package } from 'find-package-json';
+
+const ENV_CONFIG_PREFIX = 'MONGOMS_';
+
+function getPackageJson(): Package | undefined {
+  const pjIterator = finder(__dirname);
+  let next = pjIterator.next();
+  let packageJson = next.value;
+  while (!next.done) {
+    packageJson = next.value;
+    next = pjIterator.next();
+  }
+  return packageJson;
+}
+
+export default function resolveConfig(variableName: string): string | undefined {
+  const packageJson = getPackageJson();
+  return (
+    process.env[`${ENV_CONFIG_PREFIX}${variableName}`] ||
+    (packageJson &&
+      packageJson.config &&
+      packageJson.config.mongoDbMemoryServer &&
+      packageJson.config.mongoDbMemoryServer[camelCase(variableName)])
+  );
+}


### PR DESCRIPTION
Hi :)

I'd like to be able to install desired version of Mongo binary without having to prefix `npm install` with `MONGOMS_VERSION` and other env variables, and without slowing down my first run of tests. I think ability to declare binary installation options in package.json could be useful in this case.