### PR TITLE
fix(downloadUrl): elementaryOS support fixed for versions up to 0.3

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -1,4 +1,5 @@
 import getos from 'getos';
+import { execSync } from 'child_process';
 
 export interface MongoBinaryDownloadUrlOpts {
   version: string;
@@ -156,7 +157,8 @@ export default class MongoBinaryDownloadUrl {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getElementaryOSVersionString(os: getos.Os): string {
-    return 'ubuntu1404';
+    const ubuntuVersion = execSync('/usr/bin/lsb_release -u -rs');
+    return `ubuntu${ubuntuVersion.toString().replace('.', '')}`;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
It used to download the release for ubuntu 14.04 for any elementaryOS.
But different elementaryOS versions use different ubuntu base version.

So there is a need to check ubuntu versuin first and then use it to generate archive name.