### PR TITLE
Elementary os fixed

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -1,4 +1,5 @@
 import getos from 'getos';
+import { execSync } from 'child_process';
 
 export interface MongoBinaryDownloadUrlOpts {
   version: string;
@@ -156,7 +157,8 @@ export default class MongoBinaryDownloadUrl {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getElementaryOSVersionString(os: getos.Os): string {
-    return 'ubuntu1404';
+    const ubuntuVersion = execSync('/usr/bin/lsb_release -u -rs');
+    return `ubuntu${ubuntuVersion.toString().replace('.', '')}`;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -158,7 +158,10 @@ export default class MongoBinaryDownloadUrl {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getElementaryOSVersionString(os: getos.Os): string {
     const ubuntuVersion = execSync('/usr/bin/lsb_release -u -rs');
-    return `ubuntu${ubuntuVersion.toString().replace('.', '')}`;
+    return `ubuntu${ubuntuVersion
+      .toString()
+      .replace('.', '')
+      .trim()}`;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
An addition to #169
Forgot to put extra `.trim()` to take out the `\n` in the end of stdout from the command. Now is fixed.