### PR TITLE
fix: resolve to config from closest package.json

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/__tests__/resolve-config-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/resolve-config-test.ts
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import tmp from 'tmp';
+import { promisify } from 'util';
+import resolveConfig, { reInitializePackageJson } from '../resolve-config';
+
+const mkdirAsync = promisify(fs.mkdir);
+const writeFileAsync = promisify(fs.writeFile);
+
+const outerPackageJson = {
+  config: {
+    mongodbMemoryServer: {
+      version: '3.0.0',
+    },
+  },
+};
+const innerPackageJson = {
+  config: {
+    mongodbMemoryServer: {
+      version: '4.0.0',
+    },
+  },
+};
+
+describe('resolveConfig', () => {
+  const originalDir = process.cwd();
+  let tmpObj;
+
+  describe('configuration from closest package.json', () => {
+    beforeAll(async () => {
+      // Set up test project/subproject structure in a temporary directory:
+      //
+      //     project/
+      //     |-- subproject/
+      //     |   +-- package.json
+      //     +-- package.json
+
+      tmpObj = tmp.dirSync({ unsafeCleanup: true });
+      const tmpName = tmpObj.name;
+
+      await mkdirAsync(`${tmpName}/project`);
+      await mkdirAsync(`${tmpName}/project/subproject`);
+
+      // prettier-ignore
+      await Promise.all([
+        writeFileAsync(
+          `${tmpName}/project/package.json`,
+          JSON.stringify(outerPackageJson)
+        ),
+        writeFileAsync(
+          `${tmpName}/project/subproject/package.json`,
+          JSON.stringify(innerPackageJson)
+        ),
+      ]);
+    });
+
+    afterAll(() => {
+      process.chdir(originalDir);
+      tmpObj.removeCallback();
+    });
+
+    test('in project', () => {
+      process.chdir(`${tmpObj.name}/project`);
+      reInitializePackageJson();
+      const got = resolveConfig('VERSION');
+      expect(got).toBe('3.0.0');
+    });
+
+    test('in subproject', () => {
+      process.chdir(`${tmpObj.name}/project/subproject`);
+      reInitializePackageJson();
+      const got = resolveConfig('VERSION');
+      expect(got).toBe('4.0.0');
+    });
+  });
+});

--- a/packages/mongodb-memory-server-core/src/util/resolve-config.ts
+++ b/packages/mongodb-memory-server-core/src/util/resolve-config.ts
@@ -5,20 +5,19 @@ const ENV_CONFIG_PREFIX = 'MONGOMS_';
 const defaultValues = new Map<string, string>();
 
 function getPackageJson(): Package | undefined {
-  const pjIterator = finder(__dirname);
-  let next = pjIterator.next();
-  let packageJson = next.value;
-  while (!next.done) {
-    packageJson = next.value;
-    next = pjIterator.next();
-  }
-  return packageJson;
+  const pjIterator = finder(process.cwd());
+  return pjIterator.next().value;
 }
-const packageJson = getPackageJson();
 
 export function setDefaultValue(key: string, value: string): void {
   defaultValues.set(key, value);
 }
+
+let packageJson: Package | undefined;
+export function reInitializePackageJson(): void {
+  packageJson = getPackageJson();
+}
+reInitializePackageJson();
 
 export default function resolveConfig(variableName: string): string | undefined {
   return (


### PR DESCRIPTION
Fix for #187.

This also introduces reInitialisePackageJson() for test scripts. (There might be a cleaner way of doing this with `jest.resetModules()`, but I couldn't figure out how to make it work with TypeScript/ES6 imports.)

It's worth pointing out that if you have a monorepo such as the structure below and you run jest from the project directory then `subproject/test.js` will pick up the config from `project/package.json` whereas if you run jest from inside the subproject directory (or use a tool like lerna which does the same thing) then it will pick up config from `subproject/package.json`. This seems fairly logical to me, and probably as good as we can get, but perhaps others might disagree.

```
project
|-- subproject
|   |-- package.json
|   |-- test.js
|   +-- ...
|-- package.json
+-- ...
```

Note also that this change will break things for anyone who runs tests inside the subproject but has defined config in `project/package.json` to work with the original implementation. (Another possibility would be to walk down the tree of projects and stop at the first one that defines `config.mongodbMemoryServer`.)

If you think these issues need more work, I'm happy to continue working on this PR.