### PR TITLE
Use cross-spawn to help with Windows issues (take 2)

### DIFF
--- a/packages/mongodb-memory-server-core/package.json
+++ b/packages/mongodb-memory-server-core/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/nodkz/mongodb-memory-server",
   "dependencies": {
     "camelcase": "^5.3.1",
+    "cross-spawn": "^6.0.5",
     "debug": "^4.1.1",
     "decompress": "^4.2.0",
     "dedent": "^0.7.0",

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -1,4 +1,5 @@
-import { ChildProcess, spawn as spawnChild } from 'child_process';
+import { ChildProcess } from 'child_process';
+import { default as spawnChild } from 'cross-spawn';
 import path from 'path';
 import MongoBinary from './MongoBinary';
 import { MongoBinaryOpts } from './MongoBinary';
@@ -62,7 +63,7 @@ export default class MongoInstance {
         this.debug = console.log.bind(null);
       }
     } else {
-      this.debug = () => {};
+      this.debug = () => { };
     }
 
     // add instance's port to debug output

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -63,7 +63,7 @@ export default class MongoInstance {
         this.debug = console.log.bind(null);
       }
     } else {
-      this.debug = () => { };
+      this.debug = () => {};
     }
 
     // add instance's port to debug output


### PR DESCRIPTION
Fixes #180 

Ok, let's try this one more time with feeling. I used `npm pack` (thanks for the tip on the last PR) this time around to test, and I can confirm that this solves the problem for me on Windows.

As a side note, I am still seeing an `Error: EBUSY: resource busy or locked` when I try to close the database connection, but that was there before and should probably be a separate issue.