### PR TITLE
Simplify postinstall path check

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -108,7 +108,7 @@ export default class MongoBinary {
 
     // if we're in postinstall script, npm will set the cwd too deep
     let nodeModulesDLDir = process.cwd();
-    while (new RegExp(`node_modules${path.sep}mongodb-memory-server`).test(nodeModulesDLDir)) {
+    while (nodeModulesDLDir.endsWith(`node_modules${path.sep}mongodb-memory-server`)) {
       nodeModulesDLDir = path.resolve(nodeModulesDLDir, '..', '..');
     }
 


### PR DESCRIPTION
Fixes #168. The RegExp check is failing with Windows path separators because `\` is treated as a RegExp escape sequence.

I'm not able to get the project to build/run, but I'm pretty sure the logic is equivalent.