### PR TITLE
fix: re-initialise configuration using INIT_CWD in postinstall.js

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/__tests__/resolve-config-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/resolve-config-test.ts
@@ -71,5 +71,12 @@ describe('resolveConfig', () => {
       const got = resolveConfig('VERSION');
       expect(got).toBe('4.0.0');
     });
+
+    test('with explicit directory in reInitializePackageJson', () => {
+      process.chdir(`${tmpObj.name}/project`);
+      reInitializePackageJson(`${tmpObj.name}/project/subproject`);
+      const got = resolveConfig('VERSION');
+      expect(got).toBe('4.0.0');
+    });
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/resolve-config.ts
+++ b/packages/mongodb-memory-server-core/src/util/resolve-config.ts
@@ -4,8 +4,8 @@ import finder, { Package } from 'find-package-json';
 const ENV_CONFIG_PREFIX = 'MONGOMS_';
 const defaultValues = new Map<string, string>();
 
-function getPackageJson(): Package | undefined {
-  const pjIterator = finder(process.cwd());
+function getPackageJson(directory: string): Package | undefined {
+  const pjIterator = finder(directory);
   return pjIterator.next().value;
 }
 
@@ -14,8 +14,8 @@ export function setDefaultValue(key: string, value: string): void {
 }
 
 let packageJson: Package | undefined;
-export function reInitializePackageJson(): void {
-  packageJson = getPackageJson();
+export function reInitializePackageJson(directory?: string): void {
+  packageJson = getPackageJson(directory || process.cwd());
 }
 reInitializePackageJson();
 

--- a/packages/mongodb-memory-server/postinstall.js
+++ b/packages/mongodb-memory-server/postinstall.js
@@ -20,9 +20,10 @@ if (!isModuleExists('../mongodb-memory-server-core/lib/util/resolve-config')) {
   console.log('Could not resolve postinstall configuration');
   return;
 }
-const resolveConfig = require('../mongodb-memory-server-core/lib/util/resolve-config').default;
+const rc = require('../mongodb-memory-server-core/lib/util/resolve-config');
+rc.reInitializePackageJson(process.env.INIT_CWD);
 
-const envDisablePostinstall = resolveConfig('DISABLE_POSTINSTALL');
+const envDisablePostinstall = rc.default('DISABLE_POSTINSTALL');
 const skipDownload =
   typeof envDisablePostinstall === 'string' &&
   ['1', 'on', 'yes', 'true'].indexOf(envDisablePostinstall.toLowerCase()) !== -1;


### PR DESCRIPTION
Fix for issue spotted by @kjarmicki with https://github.com/nodkz/mongodb-memory-server/pull/191

This makes reInitializePackageJson() in resolve-config.ts into a semi-public interface, used by postinstall.js, taking an optional directory argument to search from.

I'm not 100% happy with this solution. I feel like it's a poor interface to have singleton config that can be poked at in this way. It opens up the possibility of action-at-a-distance. Perhaps resolve-config itself should know about INIT_CWD. That would at least make its behaviour more predictable, at the cost of making it somewhat dependent on the details of npm. As always, I'm open to better suggestions.