### PR TITLE
Addressing #74 - Wait until primary is transitioned from secondary for replicaSet

### DIFF
--- a/packages/mongodb-memory-server-core/src/__tests__/replset-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-test.ts
@@ -1,4 +1,5 @@
 import MongoMemoryReplSet from '../MongoMemoryReplSet';
+import { MongoClient } from 'mongodb';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 
@@ -40,6 +41,16 @@ describe('single server replset', () => {
       setTimeout(resolve, 500);
     });
   });
+
+  it('should be possible to connect replicaset after waitUntilRunning resolveds', async () => {
+    replSet = new MongoMemoryReplSet();
+    await replSet.waitUntilRunning();
+    const uri = await replSet.getUri();
+
+    await MongoClient.connect(`${uri}?replicaSet=testset`, {
+      useNewUrlParser: true,
+    });
+  });
 });
 
 describe('multi-member replica set', () => {
@@ -57,4 +68,15 @@ describe('multi-member replica set', () => {
     const uri = await replSet.getUri();
     expect(uri.split(',').length).toEqual(3);
   }, 40000);
+
+  it('should be possible to connect replicaset after waitUntilRunning resolveds', async () => {
+    const opts: any = { replSet: { count: 3 } };
+    replSet = new MongoMemoryReplSet(opts);
+    await replSet.waitUntilRunning();
+    const uri = await replSet.getUri();
+
+    await MongoClient.connect(`${uri}?replicaSet=testset`, {
+      useNewUrlParser: true,
+    });
+  });
 });

--- a/packages/mongodb-memory-server-core/src/types.ts
+++ b/packages/mongodb-memory-server-core/src/types.ts
@@ -30,16 +30,10 @@ export interface MongoMemoryInstancePropT extends MongoMemoryInstancePropBaseT {
   storageEngine?: StorageEngineT;
 }
 
-export interface ReplStatusMemberT {
-  _id: number;
-  name: string;
-  health: number;
-  state: number;
-  stateStr: string;
-  uptime: number;
+export interface ReplStatusReplT {
+  ismaster: boolean;
 }
 
 export interface ReplStatusResultT {
-  set: string;
-  members: ReplStatusMemberT[];
+  repl: ReplStatusReplT;
 }


### PR DESCRIPTION
My attempt to has deterministic implementation for waitUntilRunning for replicaSet, which is discussed in #74 .

Was testing if there is way to tell if its ready from `replSetGetStatus`, but my testing shows it rather shows the intention (whats going to be master) rather than actual real time status. With debug info from mongod - you can see that mongod instance is transitioning from secondary state to primary state (after voting) which takes about 2s. Also my testing shows that you get connect error until this transition is finished. And only reliable approach I found was using `serverStatus` which indicates in realtime whether its master or secondary.

Obviously `serverStatus` gives me status for the instance I am connect to, which is first server. Therefore this strategy would fail if some other instance would decide to be master initially. But in practice (testing 3 instances) always first server ended being primary, therefore this approach seems to be reliable from my testing.

Another small change was just rely on `MongoMemoryServer.start` to be resolved (which should resolve once instance starts listening) instead of waiting 1s. That shaved off about 800ms. 

On my computer (current macbook pro) I am getting pretty good times.  waitUntilRunning() gets resolved for single instance: 2100ms and multiple instance (3): 4100ms.

Let me know if you think I missed something. Thanks!
