### PR TITLE
Make properties of replSet optional

### DIFF
--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -26,15 +26,15 @@ import {
  * @property {StorageEngineT} storageEngine `mongod` storage engine type; (default: 'ephemeralForTest')
  */
 export interface ReplSetOpts {
-  auth: boolean;
-  args: string[];
-  count: number;
+  auth?: boolean;
+  args?: string[];
+  count?: number;
   dbName: string;
-  ip: string;
-  name: string;
-  oplogSize: number;
-  spawn: SpawnOptions;
-  storageEngine: StorageEngineT;
+  ip?: string;
+  name?: string;
+  oplogSize?: number;
+  spawn?: SpawnOptions;
+  storageEngine?: StorageEngineT;
   configSettings?: MongoMemoryReplSetConfigSettingsT;
 }
 


### PR DESCRIPTION
This allows overriding just a single replSet property in our test files. It shouldn't cause any issues as all changed properties already have default values.

It solves [this](https://github.com/nodkz/mongodb-memory-server/issues/189) issue.