### PR TITLE
Follow-up for 203 detect primary from stdout instead of admin call

### DIFF
--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -264,7 +264,10 @@ export default class MongoMemoryReplSet extends EventEmitter {
   async _waitForPrimary(): Promise<void> {
     await Promise.race(
       this.servers.map((server) => {
-        const instanceInfo: any = server.getInstanceInfo();
+        const instanceInfo = server.getInstanceInfo();
+        if (!instanceInfo) {
+          throw new Error('_waitForPrimary - instanceInfo not present ');
+        }
         return instanceInfo.instance.waitPrimaryReady();
       })
     );


### PR DESCRIPTION
I like this version more than #203 , because should handle correctly if any of the mongod becomes the master, not just the first one, which might be causing these occasional infinite waits on CI.

@nodkz What do you think? :-)

There is not much more I can contribute promptly. Leaving for 2 weeks holiday tomorrow and have some important things to finish off today. So hopefully this will resolve previous issues.