### PR TITLE
Migrate to vision media debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ const mongod = new MongoMemoryServer({
     dbName?: string, // by default generate random dbName
     dbPath?: string, // by default create in temp directory
     storageEngine?: string, // by default `ephemeralForTest`, available engines: [ 'devnull', 'ephemeralForTest', 'mmapv1', 'wiredTiger' ]
-    debug?: boolean, // by default false
     replSet?: string, // by default no replica set, replica set name
     auth?: boolean, // by default `mongod` is started with '--noauth', start `mongod` with '--auth'
     args?: string[], // by default no additional arguments, any additional command line arguments for `mongod` `mongod` (ex. ['--notablescan'])
@@ -101,11 +100,9 @@ const mongod = new MongoMemoryServer({
     downloadDir?: string, // by default node_modules/.cache/mongodb-memory-server/mongodb-binaries
     platform?: string, // by default os.platform()
     arch?: string, // by default os.arch()
-    debug?: boolean, // by default false
     checkMD5?: boolean, // by default false OR process.env.MONGOMS_MD5_CHECK
     systemBinary?: string, // by default undefined or process.env.MONGOMS_SYSTEM_BINARY
   },
-  debug?: boolean, // by default false
   autoStart?: boolean, // by default true
 });
 ```
@@ -117,7 +114,6 @@ MONGOMS_DOWNLOAD_DIR=/path/to/mongodb/binaries
 MONGOMS_PLATFORM=linux
 MONGOMS_ARCH=x64
 MONGOMS_VERSION=3
-MONGOMS_DEBUG=1 # also available case-insensitive values: "on" "yes" "true"
 MONGOMS_DOWNLOAD_MIRROR=host # your mirror host to download the mongodb binary
 MONGOMS_DOWNLOAD_URL=url # full URL to download the mongodb binary
 MONGOMS_DISABLE_POSTINSTALL=1 # if you want to skip download binaries on `npm i` command
@@ -139,7 +135,6 @@ Environment variables have higher priority than contents of package.json.
       "platform": "linux",
       "arch": "x64",
       "version": "3",
-      "debug": "1",
       "downloadMirror": "url",
       "disablePostinstall": "1",
       "systemBinary": "/usr/local/bin/mongod",
@@ -176,7 +171,6 @@ All options are optional.
 const replSet = new MongoMemoryReplSet({
   autoStart, // same as for MongoMemoryServer
   binary: binaryOpts, // same as for MongoMemoryServer
-  debug, // same as for MongoMemoryServer
   instanceOpts: [
     {
       args, // any additional instance specific args

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "test": "lerna run test --stream",
-    "watch": "yarn test --watchAll",
+    "watch": "lerna run watch --stream",
     "build": "tsc --build tsconfig.build.json",
     "release": "yarn build && lerna publish",
     "postinstall": "yarn build"

--- a/packages/mongodb-memory-server-core/package.json
+++ b/packages/mongodb-memory-server-core/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/nodkz/mongodb-memory-server",
   "dependencies": {
+    "@microgamma/loggator": "^1.10.18",
     "camelcase": "^5.3.1",
     "cross-spawn": "^6.0.5",
     "debug": "^4.1.1",

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -51,7 +51,6 @@ export interface MongoMemoryReplSetOptsT {
   binary: MongoBinaryOpts;
   replSet: ReplSetOpts;
   autoStart?: boolean;
-  debug?: boolean;
 }
 
 export default class MongoMemoryReplSet extends EventEmitter {
@@ -77,7 +76,6 @@ export default class MongoMemoryReplSet extends EventEmitter {
     this._state = 'stopped';
     this.opts = {
       binary: opts.binary || {},
-      debug: !!opts.debug,
       instanceOpts: opts.instanceOpts || [],
       replSet: { ...replSetDefaults, ...opts.replSet },
     };
@@ -253,7 +251,6 @@ export default class MongoMemoryReplSet extends EventEmitter {
   _startServer(instanceOpts: MongoMemoryInstancePropT): MongoMemoryServer {
     const serverOpts: MongoMemoryServerOptsT = {
       autoStart: false,
-      debug: this.opts.debug,
       binary: this.opts.binary,
       instance: instanceOpts,
       spawn: this.opts.replSet.spawn,

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -11,6 +11,7 @@ import {
   SpawnOptions,
   StorageEngineT,
 } from './types';
+import { getDebugger } from '@microgamma/loggator';
 
 /**
  * Replica set specific options.
@@ -83,10 +84,9 @@ export default class MongoMemoryReplSet extends EventEmitter {
 
     if (!this.opts.replSet.args) this.opts.replSet.args = [];
     this.opts.replSet.args.push('--oplogSize', `${this.opts.replSet.oplogSize}`);
-    this.debug = (...args: any[]) => {
-      if (!this.opts.debug) return;
-      console.log(...args);
-    };
+
+    this.debug = getDebugger(`mongodb-memory-server:core:${this.constructor.name}`);
+
     if (!(opts && opts.autoStart === false)) {
       this.debug('Autostarting MongoMemoryReplSet.');
       setTimeout(() => this.start(), 0);

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -13,7 +13,6 @@ import {
 } from './types';
 import { DirResult } from 'tmp';
 import { getDebugger } from '@microgamma/loggator';
-// import { deprecate } from './util/deprecate';
 
 tmp.setGracefulCleanup();
 

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -12,6 +12,7 @@ import {
   SpawnOptions,
 } from './types';
 import { DirResult } from 'tmp';
+import { getDebugger } from '@microgamma/loggator';
 // import { deprecate } from './util/deprecate';
 
 tmp.setGracefulCleanup();
@@ -52,11 +53,8 @@ export default class MongoMemoryServer {
   constructor(opts?: MongoMemoryServerOptsT) {
     this.opts = { ...opts };
 
-    this.debug = (msg: string) => {
-      if (this.opts.debug) {
-        console.log(msg);
-      }
-    };
+    this.debug = getDebugger(`mongodb-memory-server:core:${this.constructor.name}`);
+
     if (!(opts && opts.autoStart === false)) {
       this.debug('Autostarting MongoDB instance...');
       this.start();

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -124,7 +124,6 @@ export default class MongoMemoryServer {
     const instance = await MongoInstance.run({
       instance: {
         dbPath: data.dbPath,
-        debug: this.opts.instance && this.opts.instance.debug,
         port: data.port,
         storageEngine: data.storageEngine,
         replSet: data.replSet,
@@ -133,8 +132,7 @@ export default class MongoMemoryServer {
         ip: this.opts.instance && this.opts.instance.ip,
       },
       binary: this.opts.binary,
-      spawn: this.opts.spawn,
-      debug: this.debug,
+      spawn: this.opts.spawn
     });
     data.instance = instance;
     data.childProcess = instance.childProcess;

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -82,8 +82,7 @@ describe('MongoMemoryServer', () => {
   describe('stop()', () => {
     it('should stop mongod and answer on isRunning() method', async () => {
       const mongod = new MongoMemoryServer({
-        autoStart: false,
-        debug: false,
+        autoStart: false
       });
 
       expect(mongod.getInstanceInfo()).toBeFalsy();

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -27,7 +27,6 @@ export interface MongoBinaryOpts {
   downloadDir?: string;
   platform?: string;
   arch?: string;
-  debug?: boolean | Function;
 }
 
 export default class MongoBinary {

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -10,6 +10,8 @@ import { promisify } from 'util';
 import MongoBinaryDownload from './MongoBinaryDownload';
 import { DebugFn } from '../types';
 import resolveConfig from './resolve-config';
+import { getDebugger } from '@microgamma/loggator';
+
 
 // TODO: return back `latest` version when it will be fixed in MongoDB distro (for now use 4.0.3 😂)
 // More details in https://github.com/nodkz/mongodb-memory-server/issues/131
@@ -132,15 +134,7 @@ export default class MongoBinary {
         typeof envDebug === 'string' ? ['1', 'on', 'yes', 'true'].indexOf(envDebug) !== -1 : false,
     };
 
-    if (opts.debug) {
-      if (typeof opts.debug === 'function' && opts.debug.apply && opts.debug.call) {
-        this.debug = opts.debug as DebugFn;
-      } else {
-        this.debug = console.log.bind(null);
-      }
-    } else {
-      this.debug = (msg: string) => {}; // eslint-disable-line
-    }
+    this.debug = getDebugger(`mongodb-memory-server:core:${this.constructor.name}`);
 
     const options = { ...defaultOptions, ...opts };
     this.debug(`MongoBinary options: ${JSON.stringify(options)}`);

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -9,6 +9,7 @@ import MongoBinaryDownloadUrl from './MongoBinaryDownloadUrl';
 import { DebugFn, DebugPropT, DownloadProgressT } from '../types';
 import { LATEST_VERSION } from './MongoBinary';
 import HttpsProxyAgent from 'https-proxy-agent';
+import { getDebugger } from '@microgamma/loggator';
 
 export interface MongoBinaryDownloadOpts {
   version?: string;
@@ -38,7 +39,7 @@ export default class MongoBinaryDownload {
   version: string;
   platform: string;
 
-  constructor({ platform, arch, downloadDir, version, checkMD5, debug }: MongoBinaryDownloadOpts) {
+  constructor({ platform, arch, downloadDir, version, checkMD5 }: MongoBinaryDownloadOpts) {
     this.platform = platform || os.platform();
     this.arch = arch || os.arch();
     this.version = version || LATEST_VERSION;
@@ -57,15 +58,7 @@ export default class MongoBinaryDownload {
       lastPrintedAt: 0,
     };
 
-    if (debug) {
-      if (typeof debug === 'function' && debug.apply && debug.call) {
-        this.debug = debug;
-      } else {
-        this.debug = console.log.bind(null);
-      }
-    } else {
-      this.debug = () => {};
-    }
+    this.debug = getDebugger(`mongodb-memory-server:core:${this.constructor.name}`);
   }
 
   async getMongodPath(): Promise<string> {

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -16,7 +16,6 @@ export interface MongoBinaryDownloadOpts {
   downloadDir?: string;
   platform?: string;
   arch?: string;
-  debug?: DebugPropT;
   checkMD5?: boolean;
 }
 
@@ -29,7 +28,6 @@ interface HttpDownloadOptions {
 }
 
 export default class MongoBinaryDownload {
-  debug: DebugFn;
   dlProgress: DownloadProgressT;
   _downloadingUrl?: string;
 

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import MongoBinary from './MongoBinary';
 import { MongoBinaryOpts } from './MongoBinary';
 import { DebugPropT, StorageEngineT, SpawnOptions } from '../types';
+import { getDebugger } from '@microgamma/loggator';
 
 export interface MongodOps {
   // instance options
@@ -51,33 +52,9 @@ export default class MongoInstance {
     this.waitForPrimaryResolveFns = [];
     this.isInstancePrimary = false;
 
-    if (this.opts.debug) {
-      if (!this.opts.instance) this.opts.instance = {};
-      if (!this.opts.binary) this.opts.binary = {};
-      this.opts.instance.debug = this.opts.debug;
-      this.opts.binary.debug = this.opts.debug;
-    }
-
-    if (this.opts.instance && this.opts.instance.debug) {
-      if (
-        typeof this.opts.instance.debug === 'function' &&
-        this.opts.instance.debug.apply &&
-        this.opts.instance.debug.call
-      ) {
-        this.debug = this.opts.instance.debug;
-      } else {
-        this.debug = console.log.bind(null);
-      }
-    } else {
-      this.debug = () => {};
-    }
-
     // add instance's port to debug output
-    const debugFn = this.debug;
     const port = this.opts.instance && this.opts.instance.port;
-    this.debug = (msg: string): void => {
-      debugFn(`Mongo[${port}]: ${msg}`);
-    };
+    this.debug = getDebugger(`mongodb-memory-server:core:${this.constructor.name}:Mongo[${port}]`);
   }
 
   static run(opts: MongodOps): Promise<MongoInstance> {

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -146,8 +146,7 @@ describe('MongodbInstance', () => {
   it('should work with mongodb 4.0.3', async () => {
     const mongod = await MongodbInstance.run({
       instance: { port: 27445, dbPath: tmpDir.name },
-      binary: { version: '4.0.3' },
-      debug: true,
+      binary: { version: '4.0.3' }
     });
     const pid: any = mongod.getPid();
     expect(pid).toBeGreaterThan(0);


### PR DESCRIPTION
Hello there,

I've create this PR in other to use [visionmedia's debug](https://github.com/visionmedia/debug) instead of console.log. 

With this switch it will be enough to set `DEBUG=mongodb-memory-server:*` when you call your scripts, i.e.:
```
DEBUG=mongodb-memory-server:* yarn watch
```

Any feedback is very welcome. 

Thanks

