### PR TITLE
URL for macos change for 4.2.0

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -66,6 +66,9 @@ export default class MongoBinaryDownloadUrl {
     ) {
       name += '-ssl';
     }
+    if (this.version.indexOf('4.2') === 0) {
+      name = `mongodb-macos`;
+    }
     name += `-${this.arch}`;
     name += `-${this.version}.tgz`;
     return name;

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl-test.ts
@@ -3,6 +3,17 @@ import MongoBinaryDownloadUrl from '../MongoBinaryDownloadUrl';
 describe('MongoBinaryDownloadUrl', () => {
   describe('getDownloadUrl()', () => {
     describe('for mac', () => {
+      it('4.2', async () => {
+        const du = new MongoBinaryDownloadUrl({
+          platform: 'darwin',
+          arch: 'x64',
+          version: '4.2.0',
+        });
+        expect(await du.getDownloadUrl()).toBe(
+          'https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.2.0.tgz'
+        );
+      });
+
       it('above 3.0', async () => {
         const du = new MongoBinaryDownloadUrl({
           platform: 'darwin',


### PR DESCRIPTION
Fixes #216 

Here's what I see on https://www.mongodb.com/download-center/community

New 4.2.0 URL format is:

    https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.2.0.tgz

Previous 4.0.12 format was:

    https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.12.tgz

The change is from `osx-ssl` to `macos`. I've attempted to change this in the code, but don't have lerna installed so haven't actually run the tests.