### PR TITLE
clearTimeout when waiting for primary in replete

### DIFF
--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -263,9 +263,9 @@ export default class MongoMemoryReplSet extends EventEmitter {
   }
 
   async _waitForPrimary(timeout: number = 30000): Promise<void> {
+    let timeoutId: NodeJS.Timeout | undefined;
     const timeoutPromise = new Promise((resolve, reject) => {
-      let id = setTimeout(() => {
-        clearTimeout(id);
+      timeoutId = setTimeout(() => {
         reject('Timed out in ' + timeout + 'ms. When waiting for primary.');
       }, timeout);
     });
@@ -280,6 +280,10 @@ export default class MongoMemoryReplSet extends EventEmitter {
       }),
       timeoutPromise,
     ]);
+
+    if (timeoutId != null) {
+      clearTimeout(timeoutId);
+    }
 
     this.debug('_waitForPrimary detected one primary instance ');
   }


### PR DESCRIPTION
Hi!

My tests were hanging even after stopping the replica set, so I investigated why - turns out there is an open timer that is not cleared
