### PR TITLE
Using "useUnifiedTopology" to avoid deprecation msg

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/lockfile": "^1.0.1",
     "@types/md5-file": "^4.0.0",
     "@types/mkdirp": "^0.5.2",
-    "@types/mongodb": "^3.1.28",
+    "@types/mongodb": "^3.3.3",
     "@types/node": "^12.0.5",
     "@types/tmp": "0.1.0",
     "@types/uuid": "^3.4.4",

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -235,7 +235,11 @@ export default class MongoMemoryReplSet extends EventEmitter {
       );
     }
 
-    const conn: mongodb.MongoClient = await MongoClient.connect(uris[0], { useNewUrlParser: true });
+    const conn: mongodb.MongoClient = await MongoClient.connect(uris[0], {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+
     try {
       const db = await conn.db(this.opts.replSet.dbName);
       this.admin = db.admin();

--- a/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
@@ -13,12 +13,20 @@ let mongoServer2: MongoMemoryServer;
 beforeAll(async () => {
   mongoServer1 = new MongoMemoryServer();
   const mongoUri = await mongoServer1.getConnectionString();
-  con1 = await MongoClient.connect(mongoUri, { useNewUrlParser: true });
+  con1 = await MongoClient.connect(mongoUri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
   db1 = con1.db(await mongoServer1.getDbName());
 
   mongoServer2 = new MongoMemoryServer();
   const mongoUri2 = await mongoServer2.getConnectionString();
-  con2 = await MongoClient.connect(mongoUri2, { useNewUrlParser: true });
+  con2 = await MongoClient.connect(mongoUri2, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
   db2 = con2.db(await mongoServer1.getDbName());
 });
 

--- a/packages/mongodb-memory-server-core/src/__tests__/replset-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-test.ts
@@ -49,6 +49,7 @@ describe('single server replset', () => {
 
     await MongoClient.connect(`${uri}?replicaSet=testset`, {
       useNewUrlParser: true,
+      useUnifiedTopology: true,
     });
   });
 });
@@ -77,6 +78,7 @@ describe('multi-member replica set', () => {
 
     await MongoClient.connect(`${uri}?replicaSet=testset`, {
       useNewUrlParser: true,
+      useUnifiedTopology: true,
     });
   });
 });

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -9,7 +9,11 @@ let mongoServer: MongoMemoryServer;
 beforeAll(async () => {
   mongoServer = new MongoMemoryServer();
   const mongoUri = await mongoServer.getConnectionString();
-  con = await MongoClient.connect(mongoUri, { useNewUrlParser: true });
+  con = await MongoClient.connect(mongoUri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
   db = con.db(await mongoServer.getDbName());
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1147,7 +1147,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/mongodb@^3.1.28":
+"@types/mongodb@^3.3.3":
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.3.3.tgz#749ce52f1d958601dcc4cea3e2839a734c2723e2"
   integrity sha512-ymI6OZB4kqaSgLDFn7PYGNC+BmwbKPuw88F+gr9SGyAltcSKI6nYf+rj8hrHEsypnjtT5rA+dnmjXdPSgXgSgQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,17 +1148,17 @@
     "@types/node" "*"
 
 "@types/mongodb@^3.1.28":
-  version "3.1.28"
-  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.1.28.tgz#c049cdff343788d77f5cc8c5f2e4af72ba7d047b"
-  integrity sha512-tG+QqJ/hir2p0069ee28t2O9tlGRJKDq1WFZC2QYMlU47LGdldLL8tepfTq6aFLvP58OpwSoxaJ/qjW93ob1NQ==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.3.3.tgz#749ce52f1d958601dcc4cea3e2839a734c2723e2"
+  integrity sha512-ymI6OZB4kqaSgLDFn7PYGNC+BmwbKPuw88F+gr9SGyAltcSKI6nYf+rj8hrHEsypnjtT5rA+dnmjXdPSgXgSgQ==
   dependencies:
     "@types/bson" "*"
     "@types/node" "*"
 
 "@types/node@*":
-  version "11.13.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.2.tgz#dc85dde46aa8740bb4aed54b8104250f8f849503"
-  integrity sha512-HOtU5KqROKT7qX/itKHuTtt5fV0iXbheQvrgbLNXFJQBY/eh+VS5vmmTAVlo3qIGMsypm0G4N1t2AXjy1ZicaQ==
+  version "12.7.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.8.tgz#cb1bf6800238898bc2ff6ffa5702c3cadd350708"
+  integrity sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A==
 
 "@types/node@^12.0.5":
   version "12.0.5"


### PR DESCRIPTION
Currently, when running my tests I receive a lot of deprecation notices (see attached img), looks like MongoDB is deprecating his current topology system so they need the `useUnifiedTopology` flag set, i'm sending this PR to correct that, I also upgraded `@types/mongodb` since it was needed for this support.

![image](https://user-images.githubusercontent.com/3399236/65821624-4b2a6580-e20e-11e9-95f0-6aa816d81f9d.png)

PS: this project is great, keep it up y'all :)