### PR TITLE
Compatibility with debian 10

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -129,7 +129,9 @@ export default class MongoBinaryDownloadUrl {
   getDebianVersionString(os: getos.Os): string {
     let name = 'debian';
     const release: number = parseFloat((os as getos.LinuxOs).release);
-    if (release >= 9 || (os as getos.LinuxOs).release === 'unstable') {
+    if (release >= 10 || (os as getos.LinuxOs).release === 'unstable') {
+      name += '10';
+    } else if (release >= 9) {
       name += '92';
     } else if (release >= 8.1) {
       name += '81';


### PR DESCRIPTION
Debian 10 uses libcurl v4, thus needs a different mongodb build