### PR TITLE
Add @types/tmp to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@types/jest": "24.0.24",
     "@types/mongodb": "3.3.13",
     "@types/node": "12.12.21",
-    "@types/tmp": "0.1.0",
     "@typescript-eslint/eslint-plugin": "2.12.0",
     "@typescript-eslint/parser": "2.12.0",
     "cross-env": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@types/jest": "24.0.24",
     "@types/mongodb": "3.3.13",
     "@types/node": "12.12.21",
+    "@types/tmp": "0.1.0",
     "@typescript-eslint/eslint-plugin": "2.12.0",
     "@typescript-eslint/parser": "2.12.0",
     "cross-env": "^6.0.3",

--- a/packages/mongodb-memory-server-core/package.json
+++ b/packages/mongodb-memory-server-core/package.json
@@ -31,6 +31,9 @@
   },
   "homepage": "https://github.com/nodkz/mongodb-memory-server",
   "devDependencies": {
+    "rimraf": "^3.0.0"
+  },
+  "dependencies": {
     "@types/cross-spawn": "^6.0.1",
     "@types/decompress": "^4.2.3",
     "@types/dedent": "^0.7.0",
@@ -42,9 +45,6 @@
     "@types/mkdirp": "^0.5.2",
     "@types/tmp": "0.1.0",
     "@types/uuid": "3.4.6",
-    "rimraf": "^3.0.0"
-  },
-  "dependencies": {
     "camelcase": "^5.3.1",
     "cross-spawn": "^7.0.1",
     "debug": "^4.1.1",


### PR DESCRIPTION
Not including it in devDeps means that `strict: true` TSC projects
using mongoms currently fail to compile with:

```
node_modules/mongodb-memory-server-core/lib/MongoMemoryServer.d.ts:3:22 - error TS7016:
  Could not find a declaration file for module 'tmp'.
 'node_modules/mongodb-memory-server-core/node_modules/tmp/lib/tmp.js' implicitly has an 'any' type.
  Try `npm install @types/tmp` if it exists or add a new declaration (.d.ts) file containing `declare module 'tmp';`

3 import * as tmp from 'tmp';
                       ~~~~~
```
