### PR TITLE
Logging rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ _Note: the package does try to download `mongod` upon server start if it cannot 
 
 ## Usage
 
-### Simple server start:
+### Simple server start
 
 ```js
 import { MongoMemoryServer } from 'mongodb-memory-server';
@@ -108,7 +108,7 @@ mongod.getInstanceInfo();
 // special childProcess killer will shutdown it for you
 ```
 
-### Available options
+### Available options for MongoMemoryServer
 
 All options are optional.
 
@@ -120,7 +120,6 @@ const mongod = new MongoMemoryServer({
     dbName?: string, // by default generate random dbName
     dbPath?: string, // by default create in temp directory
     storageEngine?: string, // by default `ephemeralForTest`, available engines: [ 'devnull', 'ephemeralForTest', 'mmapv1', 'wiredTiger' ]
-    debug?: boolean, // by default false
     replSet?: string, // by default no replica set, replica set name
     auth?: boolean, // by default `mongod` is started with '--noauth', start `mongod` with '--auth'
     args?: string[], // by default no additional arguments, any additional command line arguments for `mongod` `mongod` (ex. ['--notablescan'])
@@ -130,66 +129,19 @@ const mongod = new MongoMemoryServer({
     downloadDir?: string, // by default node_modules/.cache/mongodb-memory-server/mongodb-binaries
     platform?: string, // by default os.platform()
     arch?: string, // by default os.arch()
-    debug?: boolean, // by default false
     checkMD5?: boolean, // by default false OR process.env.MONGOMS_MD5_CHECK
     systemBinary?: string, // by default undefined or process.env.MONGOMS_SYSTEM_BINARY
   },
-  debug?: boolean, // by default false
   autoStart?: boolean, // by default true
 });
 ```
 
-#### Options which can be set via ENVIRONMENT variables
-
-```sh
-MONGOMS_DOWNLOAD_DIR=/path/to/mongodb/binaries
-MONGOMS_PLATFORM=linux
-MONGOMS_ARCH=x64
-MONGOMS_VERSION=3
-MONGOMS_DEBUG=1 # also available case-insensitive values: "on" "yes" "true"
-MONGOMS_DOWNLOAD_MIRROR=host # your mirror host to download the mongodb binary
-MONGOMS_DOWNLOAD_URL=url # full URL to download the mongodb binary
-MONGOMS_DISABLE_POSTINSTALL=1 # if you want to skip download binaries on `npm i` command
-MONGOMS_SYSTEM_BINARY=/usr/local/bin/mongod # if you want to use an existing binary already on your system.
-MONGOMS_MD5_CHECK=1 # if you want to make MD5 check of downloaded binary.
-# Passed constructor parameter `binary.checkMD5` has higher priority.
-
-# GetOS specific ones (for linux only)
-MONGOMS_USE_LINUX_LSB_RELEASE # Only try "lsb_release -a"
-MONGOMS_USE_LINUX_OS_RELEASE # Only try to read "/etc/os-release"
-MONGOMS_USE_LINUX_ANYFILE_RELEASE # Only try to read the first file found "/etc/*-release"
-```
-
-#### Options which can be set via package.json's `config` section
-
-You can also use package.json's `config` section to configure installation process.
-Environment variables have higher priority than contents of package.json.
-
-```json
-{
-  "config": {
-    "mongodbMemoryServer": {
-      "downloadDir": "/path/to/mongodb/binaries",
-      "platform": "linux",
-      "arch": "x64",
-      "version": "3",
-      "debug": "1",
-      "downloadMirror": "url",
-      "disablePostinstall": "1",
-      "systemBinary": "/usr/local/bin/mongod",
-      "md5Check": "1"
-    }
-  }
-}
-```
-
-### Replica Set start:
+### Replica Set start
 
 ```js
 import { MongoMemoryReplSet } from 'mongodb-memory-server';
 
 const replSet = new MongoMemoryReplSet({
-  debug: false,
   replSet: { storageEngine: 'wiredTiger' },
 });
 await replSet.waitUntilRunning();
@@ -214,7 +166,7 @@ replSet.stop();
 // or it should be stopped automatically when you exit from script
 ```
 
-### Available options for Replica Set
+### Available options for MongoMemoryReplSet
 
 All options are optional.
 
@@ -222,7 +174,6 @@ All options are optional.
 const replSet = new MongoMemoryReplSet({
   autoStart, // same as for MongoMemoryServer
   binary: binaryOpts, // same as for MongoMemoryServer
-  debug, // same as for MongoMemoryServer
   instanceOpts: [
     {
       args, // any additional instance specific args
@@ -253,6 +204,50 @@ const replSet = new MongoMemoryReplSet({
     },
   },
 });
+```
+
+### Options which can be set via ENVIRONMENT variables
+
+```sh
+MONGOMS_DOWNLOAD_DIR=/path/to/mongodb/binaries
+MONGOMS_PLATFORM=linux
+MONGOMS_ARCH=x64
+MONGOMS_VERSION=3
+MONGOMS_DEBUG=1 # also available case-insensitive values: "on" "yes" "true"
+MONGOMS_DOWNLOAD_MIRROR=host # your mirror host to download the mongodb binary
+MONGOMS_DOWNLOAD_URL=url # full URL to download the mongodb binary
+MONGOMS_DISABLE_POSTINSTALL=1 # if you want to skip download binaries on `npm i` command
+MONGOMS_SYSTEM_BINARY=/usr/local/bin/mongod # if you want to use an existing binary already on your system.
+MONGOMS_MD5_CHECK=1 # if you want to make MD5 check of downloaded binary.
+# Passed constructor parameter `binary.checkMD5` has higher priority.
+
+# GetOS specific ones (for linux only)
+MONGOMS_USE_LINUX_LSB_RELEASE # Only try "lsb_release -a"
+MONGOMS_USE_LINUX_OS_RELEASE # Only try to read "/etc/os-release"
+MONGOMS_USE_LINUX_ANYFILE_RELEASE # Only try to read the first file found "/etc/*-release"
+```
+
+### Options which can be set via package.json's `config` section
+
+You can also use package.json's `config` section to configure installation process.
+Environment variables have higher priority than contents of package.json.
+
+```json
+{
+  "config": {
+    "mongodbMemoryServer": {
+      "downloadDir": "/path/to/mongodb/binaries",
+      "platform": "linux",
+      "arch": "x64",
+      "version": "3",
+      "debug": "1",
+      "downloadMirror": "url",
+      "disablePostinstall": "1",
+      "systemBinary": "/usr/local/bin/mongod",
+      "md5Check": "1"
+    }
+  }
+}
 ```
 
 ### Simple test with MongoClient
@@ -467,6 +462,26 @@ There isn't currently an official MongoDB release for alpine linux. This means t
 (or any other platform that isn't officially supported by MongoDB), but you can use a Docker image that already has mongod
 built in and then set the MONGOMS_SYSTEM_BINARY variable to point at that binary. This should allow you to use
 mongodb-memory-server on any system on which you can install mongod.
+
+### Enable Debug Mode
+
+The Debug mode can be enabled with an Environment-Variable or in the package.json "config" section:
+
+```sh
+MONGOMS_DEBUG=1 # also available case-insensitive values: "on" "yes" "true"
+```
+
+or
+
+```json
+{
+  "config": {
+    "mongodbMemoryServer": {
+      "debug": "1", // also available case-insensitive values: "on" "yes" "true"
+    }
+  }
+}
+```
 
 ## Travis
 

--- a/packages/mongodb-memory-server-core/package.json
+++ b/packages/mongodb-memory-server-core/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/nodkz/mongodb-memory-server",
   "devDependencies": {
     "@types/cross-spawn": "^6.0.1",
+    "@types/debug": "^4.1.5",
     "@types/decompress": "^4.2.3",
     "@types/dedent": "^0.7.0",
     "@types/find-cache-dir": "^2.0.0",

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -59,7 +59,6 @@ describe('MongoMemoryServer', () => {
       expect(MongoMemoryServer.prototype._startUpInstance).toHaveBeenCalledTimes(0);
 
       await expect(mongoServer.start()).rejects.toThrow('unknown error');
-      expect(console.warn).toHaveBeenCalled();
 
       expect(MongoMemoryServer.prototype._startUpInstance).toHaveBeenCalledTimes(1);
     });

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -83,7 +83,6 @@ describe('MongoMemoryServer', () => {
     it('should stop mongod and answer on isRunning() method', async () => {
       const mongod = new MongoMemoryServer({
         autoStart: false,
-        debug: false,
       });
 
       expect(mongod.getInstanceInfo()).toBeFalsy();

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -40,7 +40,7 @@ describe('Single mongoServer', () => {
     const mongoServer2 = new MongoMemoryServer({ autoStart: false });
     mongoServer2.runningInstance = Promise.resolve({}) as Promise<MongoInstanceDataT>;
     await expect(mongoServer2.start()).rejects.toThrow(
-      'MongoDB instance already in status startup/running/error. Use opts.debug = true for more info.'
+      'MongoDB instance already in status startup/running/error. Use debug for more info.'
     );
   });
 });

--- a/packages/mongodb-memory-server-core/src/index.ts
+++ b/packages/mongodb-memory-server-core/src/index.ts
@@ -1,3 +1,5 @@
+import './util/resolve-config'; // import it for the side-effects (globals)
+
 import MongoBinary from './util/MongoBinary';
 import MongoInstance from './util/MongoInstance';
 import MongoMemoryServer from './MongoMemoryServer';

--- a/packages/mongodb-memory-server-core/src/types.ts
+++ b/packages/mongodb-memory-server-core/src/types.ts
@@ -1,5 +1,5 @@
 export type DebugFn = (...args: any[]) => any;
-export type DebugPropT = boolean | DebugFn;
+export type DebugPropT = boolean;
 
 export interface DownloadProgressT {
   current: number;
@@ -24,7 +24,6 @@ export interface MongoMemoryInstancePropBaseT {
 export interface MongoMemoryInstancePropT extends MongoMemoryInstancePropBaseT {
   auth?: boolean;
   dbName?: string;
-  debug?: DebugPropT;
   ip?: string; // for binding to all IP addresses set it to `::,0.0.0.0`, by default '127.0.0.1'
   replSet?: string;
   storageEngine?: StorageEngineT;

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -1,6 +1,9 @@
 import getOS, { AnyOS, LinuxOS } from './getos';
 import { execSync } from 'child_process';
 import resolveConfig from './resolve-config';
+import debug from 'debug';
+
+const log = debug('MongoMS:MongoBinaryDownloadUrl');
 
 export interface MongoBinaryDownloadUrlOpts {
   version: string;
@@ -28,11 +31,16 @@ export default class MongoBinaryDownloadUrl {
    */
   async getDownloadUrl(): Promise<string> {
     const archive = await this.getArchiveName();
+    log(`Using "${archive}" as the Archive String`);
 
     const downloadUrl = resolveConfig('DOWNLOAD_URL');
-    if (downloadUrl) return downloadUrl;
+    if (downloadUrl) {
+      log(`Using "${downloadUrl}" as the Download-URL`);
+      return downloadUrl;
+    }
 
     const mirror = resolveConfig('DOWNLOAD_MIRROR') ?? 'https://fastdl.mongodb.org';
+    log(`Using "${mirror}" as the mirror`);
 
     return `${mirror}/${this.platform}/${archive}`;
   }

--- a/packages/mongodb-memory-server-core/src/util/resolve-config.ts
+++ b/packages/mongodb-memory-server-core/src/util/resolve-config.ts
@@ -1,5 +1,6 @@
 import camelCase from 'camelcase';
 import finder, { Package } from 'find-package-json';
+import debug from 'debug';
 
 const ENV_CONFIG_PREFIX = 'MONGOMS_';
 const defaultValues = new Map<string, string>();
@@ -37,4 +38,9 @@ export default function resolveConfig(variableName: string): string | undefined 
  */
 export function envToBool(env: string) {
   return ['1', 'on', 'yes', 'true'].indexOf(env.toLowerCase()) !== -1;
+}
+
+// enable debug "MONGOMS_DEBUG" is true
+if (envToBool(resolveConfig('DEBUG') ?? '')) {
+  debug.enable('MongoMS:*');
 }

--- a/packages/mongodb-memory-server-core/tsconfig.build.json
+++ b/packages/mongodb-memory-server-core/tsconfig.build.json
@@ -10,7 +10,7 @@
     "declarationMap": true,
     "skipLibCheck": false,
     "strict": true,
-    "lib": ["es2017"],
+    "lib": ["esnext"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/mongodb-memory-server-core/tsconfig.json
+++ b/packages/mongodb-memory-server-core/tsconfig.json
@@ -10,7 +10,7 @@
     "declarationMap": true,
     "skipLibCheck": false,
     "strict": true,
-    "lib": ["es2017"],
+    "lib": ["esnext"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,6 +1155,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/debug@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
+  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
+
 "@types/decompress@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/decompress/-/decompress-4.2.3.tgz#98eed48af80001038aa05690b2094915f296fe65"


### PR DESCRIPTION
- Add Dev-dependency "@types/debug" (the normal `debug` package is already an dependency, but never used)
- Change Typescript lib from "es2017" to "esnext" (just to be sure to be able to work with new things, they will get compiled down)
- Added some Logging to "MongoBinaryDownloadUrl"
- Transformed logging to use "debug"
- "resolve-config" now gets loaded in index as an side-effect (to load MONGOMS_DEBUG)
- Added "Enable Debug Mode" section to README
- Reorganized the README's documented options
- Changed `MONGOMS_DEBUG` to enable `debug.('MongoMS:*')`
- `DEBUG=MongoMS:*` will now work as an environment variable too (cant be disabled)

The only file where i didnt remove `this.debug` is `MongoInstance` because it contains the STDOUT of Mong-Instances

## Related Issues

- fixes #262 

---

please know that this is not intended to be merged right away