### PR TITLE
insensitive the regexp when a primary is elected

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -271,7 +271,7 @@ export default class MongoInstance {
       }
     } else if (/\*\*\*aborting after/i.test(line)) {
       this.instanceFailed('Mongod internal error');
-    } else if (/transition to primary complete; database writes are now permitted/.test(line)) {
+    } else if (/transition to primary complete; database writes are now permitted/i.test(line)) {
       this.isInstancePrimary = true;
       this.debug('Calling all waitForPrimary resolve functions');
       this.waitForPrimaryResolveFns.forEach((resolveFn) => resolveFn(true));


### PR DESCRIPTION
insensitive the regexp when a primary is elected because on mongo 4.4 the stdout message has a capital letter

## Related Issues
fixes #292
