### PR TITLE
Fix #162 - read strict-ssl from npm config

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -31,6 +31,7 @@ interface HttpDownloadOptions {
   port: string;
   path: string;
   method: 'GET' | 'POST';
+  rejectUnauthorized?: boolean;
   agent: HttpsProxyAgent | undefined;
 }
 
@@ -145,6 +146,8 @@ export default class MongoBinaryDownload {
       process.env.HTTPS_PROXY ||
       process.env.HTTP_PROXY;
 
+    const strictSsl = process.env['npm_config_strict-ssl'] === 'false' ? false : true;
+
     const urlObject = url.parse(downloadUrl);
 
     if (!urlObject.hostname || !urlObject.path) {
@@ -156,6 +159,7 @@ export default class MongoBinaryDownload {
       port: urlObject.port || '443',
       path: urlObject.path,
       method: 'GET',
+      rejectUnauthorized: strictSsl,
       agent: proxy ? new HttpsProxyAgent(proxy) : undefined,
     };
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload-test.ts
@@ -53,6 +53,32 @@ MONGOMS_MD5_CHECK environment variable`, () => {
     expect(callArg1.agent.proxy.href).toBe('http://user:pass@proxy:8080/');
   });
 
+  it('should not reject unauthorized when strict-ssl is false in env vars', async () => {
+    process.env['npm_config_strict-ssl'] = 'false';
+
+    const du = new MongoBinaryDownload({});
+    du.httpDownload = jest.fn();
+
+    await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
+    expect(du.httpDownload).toHaveBeenCalledTimes(1);
+    const callArg1 = (du.httpDownload as jest.Mock).mock.calls[0][0];
+    expect(callArg1.rejectUnauthorized).toBeDefined();
+    expect(callArg1.rejectUnauthorized).toBe(false);
+  });
+
+  it('should reject unauthorized when strict-ssl is not in env vars', async () => {
+    delete process.env['npm_config_strict-ssl'];
+
+    const du = new MongoBinaryDownload({});
+    du.httpDownload = jest.fn();
+
+    await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
+    expect(du.httpDownload).toHaveBeenCalledTimes(1);
+    const callArg1 = (du.httpDownload as jest.Mock).mock.calls[0][0];
+    expect(callArg1.rejectUnauthorized).toBeDefined();
+    expect(callArg1.rejectUnauthorized).toBe(true);
+  });
+
   it(`makeMD5check returns true if md5 of downloaded mongoDBArchive is
 the same as in the reference result`, () => {
     const someMd5 = 'md5';


### PR DESCRIPTION
## Related Issues
- #162 postinstall fail on certificate issue:

Reads `'strict-ssl'` from npm config so that users can workaround potential certificate chain issues that prevent downloading the mongodb binary.
Retains the [default as true](https://docs.npmjs.com/misc/config#strict-ssl) if the value is not specified or is a value other than `'false'`.