### PR TITLE
Fix #308 - read strict-ssl from npm config

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -146,7 +146,7 @@ export default class MongoBinaryDownload {
       process.env.HTTPS_PROXY ||
       process.env.HTTP_PROXY;
 
-    const strictSsl = process.env['npm_config_strict-ssl'] === 'false' ? false : true;
+    const strictSsl = process.env.npm_config_strict_ssl === 'true';
 
     const urlObject = url.parse(downloadUrl);
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload-test.ts
@@ -53,8 +53,9 @@ MONGOMS_MD5_CHECK environment variable`, () => {
     expect(callArg1.agent.proxy.href).toBe('http://user:pass@proxy:8080/');
   });
 
-  it('should not reject unauthorized when strict-ssl is false in env vars', async () => {
-    process.env['npm_config_strict-ssl'] = 'false';
+  it('should not reject unauthorized when npm strict-ssl config is false', async () => {
+    // npm sets false config value as empty string in env vars
+    process.env['npm_config_strict_ssl'] = '';
 
     const du = new MongoBinaryDownload({});
     du.httpDownload = jest.fn();
@@ -66,8 +67,9 @@ MONGOMS_MD5_CHECK environment variable`, () => {
     expect(callArg1.rejectUnauthorized).toBe(false);
   });
 
-  it('should reject unauthorized when strict-ssl is not in env vars', async () => {
-    delete process.env['npm_config_strict-ssl'];
+  it('should reject unauthorized when npm strict-ssl config is true', async () => {
+    // npm sets true config value as string 'true' in env vars
+    process.env['npm_config_strict_ssl'] = 'true';
 
     const du = new MongoBinaryDownload({});
     du.httpDownload = jest.fn();


### PR DESCRIPTION
<!--
## Make sure you have done these steps

- Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

Fix for #308 :

- Read from environment variable `npm_config_strict_ssl` (i.e. all underscores)
- Will honour whatever the npm config value is. npm/yarn will set true properties to the string 'true' and false properties to an empty string. The current npm default is `true` so even without specifying `--strict-ssl` this will be set to 'true' in environment variables.
