### PR TITLE
docs: explaining clearly how to install non latest binary + toc added

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,39 @@ Every `MongoMemoryServer` instance creates and starts a fresh MongoDB server on 
 
 Works perfectly [with Travis CI](https://github.com/nodkz/graphql-compose-mongoose/commit/7a6ac2de747d14281f9965f418065e97a57cfb37) without additional `services` and `addons` options in `.travis.yml`.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Installation](#installation)
+  - [Requirements](#requirements)
+    - [Known Incompatibilities](#known-incompatibilities)
+  - [mongodb-memory-server](#mongodb-memory-server)
+    - [Installing with non-latest binary](#installing-with-non-latest-binary)
+  - [mongodb-memory-server-global](#mongodb-memory-server-global)
+  - [mongodb-memory-server-core](#mongodb-memory-server-core)
+- [Usage](#usage)
+  - [Simple server start](#simple-server-start)
+  - [Available options for MongoMemoryServer](#available-options-for-mongomemoryserver)
+  - [Replica Set start](#replica-set-start)
+  - [Available options for MongoMemoryReplSet](#available-options-for-mongomemoryreplset)
+  - [Options which can be set via ENVIRONMENT variables](#options-which-can-be-set-via-environment-variables)
+  - [Options which can be set via package.json's `config` section](#options-which-can-be-set-via-packagejsons-config-section)
+  - [Simple test with MongoClient](#simple-test-with-mongoclient)
+  - [Provide connection string to mongoose](#provide-connection-string-to-mongoose)
+  - [Several mongoose connections simultaneously](#several-mongoose-connections-simultaneously)
+  - [Simple Mocha/Chai test example](#simple-mochachai-test-example)
+  - [Simple Jest test example](#simple-jest-test-example)
+  - [AVA test runner](#ava-test-runner)
+  - [Docker Alpine](#docker-alpine)
+  - [Enable Debug Mode](#enable-debug-mode)
+- [Travis](#travis)
+- [Credits](#credits)
+- [License](#license)
+- [Maintainers](#maintainers)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Installation
 
 This tool provides three packages for different purposes:
@@ -46,7 +79,7 @@ And one of those:
 - ArchLinux & Alpine do not have an offical mongodb build
 - ArchLinux(Docker) does not have an `/etc/os-release` file by default
 
-### `mongodb-memory-server`
+### mongodb-memory-server
 
 Auto-downloads the latest `mongod` binary on npm install to: `node_modules/.cache/mongodb-binaries`.
 
@@ -56,7 +89,16 @@ yarn add mongodb-memory-server --dev
 npm install mongodb-memory-server --save-dev
 ```
 
-### `mongodb-memory-server-global`
+#### Installing with non-latest binary
+By setting [ENVIRONMENT variable](#options-which-can-be-set-via-environment-variables) you are able to configure mongodb-memory-server to download a specific mongodb binary version:
+
+```bash
+export MONGOMS_DOWNLOAD_URL=https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.8.tgz
+export MONGOMS_VERSION=4.2.8
+```
+
+
+### mongodb-memory-server-global
 
 Auto-downloads the latest `mongod` binary on npm install to: `%HOME%/.cache/mongodb-binaries` / `~/.cache/mongodb-binaries`.
 
@@ -66,7 +108,7 @@ yarn add mongodb-memory-server-global --dev
 npm install mongodb-memory-server-global --save-dev
 ```
 
-### `mongodb-memory-server-core`
+### mongodb-memory-server-core
 
 Does NOT auto-download `mongod` on npm install.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This package spins up an actual/real MongoDB server programmatically from node, for testing or mocking during development. By default it holds the data in memory. A fresh spun up `mongod` process takes about 7Mb of memory. The server will allow you to connect your favorite ODM or client library to the MongoDB server and run integration tests isolated from each other.
 
-On install, this package downloads the latest MongoDB binaries and saves them to a cache folder.
+On install, this [package downloads](#configuring-which-mongod-binary-to-use) the latest MongoDB binaries and saves them to a cache folder.
 
 On starting a new instance of the memory server, if the binary cannot be found, it will be auto-downloaded, thus the first run may take some time. All further runs will be fast, because they will use the downloaded binaries.
 
@@ -28,9 +28,9 @@ Works perfectly [with Travis CI](https://github.com/nodkz/graphql-compose-mongoo
   - [Requirements](#requirements)
     - [Known Incompatibilities](#known-incompatibilities)
   - [mongodb-memory-server](#mongodb-memory-server)
-    - [Installing with non-latest binary](#installing-with-non-latest-binary)
   - [mongodb-memory-server-global](#mongodb-memory-server-global)
   - [mongodb-memory-server-core](#mongodb-memory-server-core)
+  - [Configuring which mongod binary to use](#configuring-which-mongod-binary-to-use)
 - [Usage](#usage)
   - [Simple server start](#simple-server-start)
   - [Available options for MongoMemoryServer](#available-options-for-mongomemoryserver)
@@ -89,15 +89,6 @@ yarn add mongodb-memory-server --dev
 npm install mongodb-memory-server --save-dev
 ```
 
-#### Installing with non-latest binary
-By setting [ENVIRONMENT variable](#options-which-can-be-set-via-environment-variables) you are able to configure mongodb-memory-server to download a specific mongodb binary version:
-
-```bash
-export MONGOMS_DOWNLOAD_URL=https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.8.tgz
-export MONGOMS_VERSION=4.2.8
-```
-
-
 ### mongodb-memory-server-global
 
 Auto-downloads the latest `mongod` binary on npm install to: `%HOME%/.cache/mongodb-binaries` / `~/.cache/mongodb-binaries`.
@@ -119,6 +110,14 @@ npm install mongodb-memory-server-core --save-dev
 ```
 
 _Note: the package does try to download `mongod` upon server start if it cannot find the binary._
+
+### Configuring which mongod binary to use
+The default behaviour is that the latest version for your OS will be downloaded. By setting [ENVIRONMENT variables](#options-which-can-be-set-via-environment-variables) you are able to specify which version and binary will be downloaded:
+
+```bash
+export MONGOMS_DOWNLOAD_URL=https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.8.tgz
+export MONGOMS_VERSION=4.2.8
+```
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jest": "jest --env node",
     "build": "tsc --build tsconfig.build.json",
     "release": "lerna publish --conventional-commits",
+    "readme:toc": "npx doctoc ./README.md",
     "postinstall": "yarn build"
   }
 }


### PR DESCRIPTION

- There were no clear sections in the readme on installing mongo above the latest version, eg 4.2.8 on Linux Mint.
- There were no table of contents making the docs hard to jump through, doctoc added for automatically building the main readme
