### PR TITLE
Fix URL generation for MongoDB 4.4

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -337,7 +337,7 @@ export default class MongoBinaryDownloadUrl {
       case 'darwin':
         return 'osx';
       case 'win32':
-        return /^[4-9]\.[4-9]/.test(this.version) ? 'windows' : 'win32';
+        return /^(4\.[4-9]|[5-9])/.test(this.version) ? 'windows' : 'win32';
       case 'linux':
       case 'elementary OS':
         return 'linux';

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -57,6 +57,7 @@ export default class MongoBinaryDownloadUrl {
       case 'osx':
         return this.getArchiveNameOsx();
       case 'win32':
+      case 'windows':
         return this.getArchiveNameWin();
       case 'linux':
       default:
@@ -71,9 +72,9 @@ export default class MongoBinaryDownloadUrl {
   async getArchiveNameWin(): Promise<string> {
     let name = `mongodb-${this.platform}`;
     name += `-${this.arch}`;
-    if (this.version.indexOf('4.2') === 0) {
+    if (this.version.startsWith('4.2')) {
       name += '-2012plus';
-    } else {
+    } else if (/^[1-3]\./.test(this.version)) {
       name += '-2008plus-ssl';
     }
     name += `-${this.version}.zip`;
@@ -336,7 +337,7 @@ export default class MongoBinaryDownloadUrl {
       case 'darwin':
         return 'osx';
       case 'win32':
-        return 'win32';
+        return /^[4-9]\.[4-9]/.test(this.version) ? 'windows' : 'win32';
       case 'linux':
       case 'elementary OS':
         return 'linux';

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -88,14 +88,14 @@ export default class MongoBinaryDownloadUrl {
     let name = `mongodb-osx`;
     if (
       !(
-        this.version.indexOf('3.0') === 0 ||
-        this.version.indexOf('2.') === 0 ||
-        this.version.indexOf('1.') === 0
+        this.version.startsWith('3.0') ||
+        this.version.startsWith('2.') ||
+        this.version.startsWith('1.')
       )
     ) {
       name += '-ssl';
     }
-    if (this.version.indexOf('4.2') === 0) {
+    if (this.version.startsWith('4.')) {
       name = `mongodb-macos`;
     }
     name += `-${this.arch}`;

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl-test.ts
@@ -3,14 +3,14 @@ import MongoBinaryDownloadUrl from '../MongoBinaryDownloadUrl';
 describe('MongoBinaryDownloadUrl', () => {
   describe('getDownloadUrl()', () => {
     describe('for mac', () => {
-      it('4.2', async () => {
+      it('4.4', async () => {
         const du = new MongoBinaryDownloadUrl({
           platform: 'darwin',
           arch: 'x64',
-          version: '4.2.0',
+          version: '4.4.0',
         });
         expect(await du.getDownloadUrl()).toBe(
-          'https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.2.0.tgz'
+          'https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.4.0.tgz'
         );
       });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl-test.ts
@@ -91,6 +91,17 @@ describe('MongoBinaryDownloadUrl', () => {
       );
     });
 
+    it('4.4 for win32', async () => {
+      const du = new MongoBinaryDownloadUrl({
+        platform: 'win32',
+        arch: 'x64',
+        version: '4.4.0',
+      });
+      expect(await du.getDownloadUrl()).toBe(
+        'https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-4.4.0.zip'
+      );
+    });
+
     it('fallback', async () => {
       console.warn = jest.fn(); // mock it to prevent writing to console
 


### PR DESCRIPTION
This PR fixes download URL generation for MongoDB 4.4 for macOS and Windows platforms.
