### PR TITLE
Match README description for checkMD5

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -8,7 +8,7 @@ import { execSync } from 'child_process';
 import dedent from 'dedent';
 import { promisify } from 'util';
 import MongoBinaryDownload from './MongoBinaryDownload';
-import resolveConfig from './resolve-config';
+import resolveConfig, { envToBool } from './resolve-config';
 import debug from 'debug';
 
 const log = debug('MongoMS:MongoBinary');
@@ -27,6 +27,7 @@ export interface MongoBinaryOpts {
   downloadDir?: string;
   platform?: string;
   arch?: string;
+  checkMD5?: boolean;
 }
 
 export default class MongoBinary {
@@ -52,7 +53,7 @@ export default class MongoBinary {
   }
 
   static async getDownloadPath(options: Required<MongoBinaryOpts>): Promise<string> {
-    const { downloadDir, platform, arch, version } = options;
+    const { downloadDir, platform, arch, version, checkMD5 } = options;
     // create downloadDir if not exists
     await mkdirp(downloadDir);
 
@@ -82,6 +83,7 @@ export default class MongoBinary {
         platform,
         arch,
         version,
+        checkMD5,
       });
       this.cache[version] = await downloader.getMongodPath();
     }
@@ -121,6 +123,7 @@ export default class MongoBinary {
       arch: resolveConfig('ARCH') || os.arch(),
       version: resolveConfig('VERSION') || LATEST_VERSION,
       systemBinary: resolveConfig('SYSTEM_BINARY'),
+      checkMD5: envToBool(resolveConfig('MD5_CHECK') ?? ''),
     };
 
     const options = { ...defaultOptions, ...opts };

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -120,6 +120,7 @@ export default class MongoBinaryDownload {
     if (!this.checkMD5) {
       return undefined;
     }
+    log(`checking against md5`);
     const mongoDBArchiveMd5 = await this.download(urlForReferenceMD5);
     const signatureContent = fs.readFileSync(mongoDBArchiveMd5).toString('utf-8');
     const m = signatureContent.match(/(.*?)\s/);
@@ -128,6 +129,7 @@ export default class MongoBinaryDownload {
     if (md5Remote !== md5Local) {
       throw new Error('MongoBinaryDownload: md5 check failed');
     }
+    log(`md5 local: ${md5Local}, md5 remote: ${md5Remote}`);
     return true;
   }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -120,16 +120,16 @@ export default class MongoBinaryDownload {
     if (!this.checkMD5) {
       return undefined;
     }
-    log(`checking against md5`);
+    log('Checking MD5 of downloaded binary...');
     const mongoDBArchiveMd5 = await this.download(urlForReferenceMD5);
     const signatureContent = fs.readFileSync(mongoDBArchiveMd5).toString('utf-8');
     const m = signatureContent.match(/(.*?)\s/);
     const md5Remote = m ? m[1] : null;
     const md5Local = md5File.sync(mongoDBArchive);
+    log(`Local MD5: ${md5Local}, Remote MD5: ${md5Remote}`);
     if (md5Remote !== md5Local) {
       throw new Error('MongoBinaryDownload: md5 check failed');
     }
-    log(`md5 local: ${md5Local}, md5 remote: ${md5Remote}`);
     return true;
   }
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary-test.ts
@@ -58,6 +58,7 @@ describe('MongoBinary', () => {
         platform: os.platform(),
         arch: os.arch(),
         version,
+        checkMD5: false,
       });
 
       expect(mockGetMongodPath).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
<!--
## Make sure you have done these steps

- Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->
This PR updates the code to follow the README.

I noticed the checkMD5 option was not available on the `MongoMemoryServer` class constructor, though the README indicated it is an option.

Here's a quick PR passing through the option to do an MD5 check for the downloaded mongo binary.

I also added two quick log statements in the MD5 check function. If that's a problem I can take them out, but they were useful to me and may be useful to someone else running in debug mode.
