### PR TITLE
fix: fix "Invalid Semver version"

### DIFF
--- a/packages/mongodb-memory-server-core/package.json
+++ b/packages/mongodb-memory-server-core/package.json
@@ -63,7 +63,6 @@
     "camelcase": "^6.0.0",
     "cross-spawn": "^7.0.3",
     "debug": "^4.1.1",
-    "dedent": "^0.7.0",
     "find-cache-dir": "^3.3.1",
     "find-package-json": "^1.2.0",
     "get-port": "^5.1.1",

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -5,7 +5,6 @@ import LockFile from 'lockfile';
 import mkdirp from 'mkdirp';
 import findCacheDir from 'find-cache-dir';
 import { execSync } from 'child_process';
-import dedent from 'dedent';
 import { promisify } from 'util';
 import MongoBinaryDownload from './MongoBinaryDownload';
 import resolveConfig, { envToBool } from './resolve-config';
@@ -147,13 +146,12 @@ export default class MongoBinary {
 
         if (version !== LATEST_VERSION && version !== binaryVersion) {
           // we will log the version number of the system binary and the version requested so the user can see the difference
-          log(dedent`
-            MongoMemoryServer: Possible version conflict
-              SystemBinary version: ${binaryVersion}
-              Requested version:    ${version}
-
-              Using SystemBinary!
-          `);
+          log(
+            'MongoMemoryServer: Possible version conflict\n' +
+              `  SystemBinary version: ${binaryVersion}\n` +
+              `  Requested version:    ${version}\n\n` +
+              '  Using SystemBinary!'
+          );
         }
       }
     }

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -14,7 +14,6 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import { promisify } from 'util';
 import resolveConfig, { envToBool } from './resolve-config';
 import debug from 'debug';
-import dedent from 'dedent';
 
 const log = debug('MongoMS:MongoBinaryDownload');
 
@@ -324,10 +323,10 @@ export default class MongoBinaryDownload {
           if (response.statusCode != 200) {
             if (response.statusCode === 403) {
               reject(
-                new Error(dedent`
-                  Status Code is 403 (MongoDB's 404)\n
-                  This means that the requested version-platform combination dosnt exist
-                `)
+                new Error(
+                  "Status Code is 403 (MongoDB's 404)\n" +
+                    "This means that the requested version-platform combination doesn't exist"
+                )
               );
               return;
             }

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl-test.ts
@@ -3,6 +3,17 @@ import MongoBinaryDownloadUrl from '../MongoBinaryDownloadUrl';
 describe('MongoBinaryDownloadUrl', () => {
   describe('getDownloadUrl()', () => {
     describe('for mac', () => {
+      it('latest', async () => {
+        const du = new MongoBinaryDownloadUrl({
+          platform: 'darwin',
+          arch: 'x64',
+          version: 'latest',
+        });
+        expect(await du.getDownloadUrl()).toBe(
+          'https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-latest.tgz'
+        );
+      });
+
       it('4.4', async () => {
         const du = new MongoBinaryDownloadUrl({
           platform: 'darwin',
@@ -100,6 +111,17 @@ describe('MongoBinaryDownloadUrl', () => {
         });
         expect(await du.getDownloadUrl()).toBe(
           'https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-4.4.0.zip'
+        );
+      });
+
+      it('latest (windows)', async () => {
+        const du = new MongoBinaryDownloadUrl({
+          platform: 'win32',
+          arch: 'x64',
+          version: 'latest',
+        });
+        expect(await du.getDownloadUrl()).toBe(
+          'https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-latest.zip'
         );
       });
     });


### PR DESCRIPTION
- add tests for "latest" for macos & windows
- fix "Invalid Version: latest" for macos & windows
- replace all occurences with "dedent" with proper strings

## Related Issues

- closes nodkz/mongodb-memory-server#345
- closes nodkz/mongodb-memory-server#335