### PR TITLE
add workflow "stale"

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+# https://github.com/actions/stale
+
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'Marking Issue as stale, will be closed in 7 days if no more activity is seen'
+          close-issue-message: 'Closing Issue because it is marked as stale'
+          stale-issue-label: stale
+          only-labels: question,can't reproduce,Needs More Information,needs repro script,stale
+          exempt-issue-labels: help wanted,docs,enhancement,feature,dependencies
+          days-before-stale: 60
+          days-before-close: 7
+          remove-stale-when-updated: true


### PR DESCRIPTION
- add github workflow "stale"

settings:
- runs once every day
- runs only on these tags: `question,can't reproduce,Needs More Information,needs repro script,stale`
- definitely doesnt run on these tags: `help wanted,docs,enhancement,feature,dependencies`
- marks issues as stale if there is no activity in 60 days
- closes issues when the date tagging with `stale` is older than 7 days
- removes stale tag on activity