### PR TITLE
Fix/mongo killer

### DIFF
--- a/packages/mongodb-memory-server-core/package.json
+++ b/packages/mongodb-memory-server-core/package.json
@@ -88,6 +88,7 @@
     "lint": "npm run eslint && npm run tscheck",
     "eslint": "eslint -c ../../.eslintrc.js 'src/**/*.{js,ts}'",
     "test": "npm run lint && npm run coverage",
+    "test:watch": "npm run watch",
     "tscheck": "tsc --noEmit"
   }
 }

--- a/packages/mongodb-memory-server-core/scripts/mongo_killer.js
+++ b/packages/mongodb-memory-server-core/scripts/mongo_killer.js
@@ -7,28 +7,61 @@
     - kill itself
 */
 
+/**
+ * Because since node 4.0.0 the internal util.is* functions got deprecated
+ * @param {any} val Any value to test if null or undefined
+ */
+function isNullOrUndefined(val) {
+  return val === null || val === undefined;
+}
+
+/**
+ * Check if the given Process is still alive
+ * @param {number} pid The Process PID
+ */
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+// the following line is just to ensure this process gets actually exited
+process.on('SIGINT', () => process.exit(0));
+
 const parentPid = parseInt(process.argv[2], 10);
 const childPid = parseInt(process.argv[3], 10);
 
-if (parentPid && childPid) {
-  setInterval(() => {
-    // if parent dead
+function check() {
+  // if parent dead
+  if (!isAlive(parentPid)) {
+    console.log('mongo_killer: parentPid not alive');
     try {
-      process.kill(parentPid, 0);
-    } catch (e) {
-      try {
-        process.kill(childPid);
-      } catch (ee) {
-        // doesnt matter if it is dead
-      }
-      process.exit();
+      process.kill(childPid);
+    } catch (err) {
+      console.log('mongo_killer: couldnt kill child:', err);
     }
+    process.exit();
+  }
 
-    // if child dead
-    try {
-      process.kill(childPid, 0);
-    } catch (e) {
-      process.exit();
-    }
-  }, 2000);
+  // if child dead
+  if (!isAlive(childPid)) {
+    console.log('mongo_killer: childPid not alive');
+    process.exit();
+  }
 }
+
+if (isNullOrUndefined(parentPid) || Number.isNaN(parentPid)) {
+  console.log('mongo_killer: parentPid is undefined or NaN!');
+  process.exit(-1);
+}
+
+if (isNullOrUndefined(childPid) || Number.isNaN(childPid)) {
+  console.log('mongo_killer: childPid is undefined or NaN!');
+  process.exit(-1);
+}
+
+check(); // run once before the interval
+setInterval(check, 2000);

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -204,7 +204,7 @@ export default class MongoInstance {
     this.debug(`Called MongoInstance._launchKiller(parent: ${parentPid}, child: ${childPid}):`);
     // spawn process which kills itself and mongo process if current process is dead
     const killer = spawnChild(
-      process.argv[0],
+      process.env['NODE'] ?? process.argv[0], // try Environment variable "NODE" before using argv[0]
       [
         path.resolve(__dirname, '../../scripts/mongo_killer.js'),
         parentPid.toString(),

--- a/packages/mongodb-memory-server-core/src/util/db_util.ts
+++ b/packages/mongodb-memory-server-core/src/util/db_util.ts
@@ -23,4 +23,12 @@ export function getUriBase(host: string, port: number, dbName: string): string {
   return `mongodb://${host}:${port}/${dbName}?`;
 }
 
+/**
+ * Because since node 4.0.0 the internal util.is* functions got deprecated
+ * @param val Any value to test if null or undefined
+ */
+export function isNullOrUndefined(val: unknown): val is null | undefined {
+  return val === null || val === undefined;
+}
+
 export default generateDbName;


### PR DESCRIPTION
- refactor `scripts/mongo_killer.js` to make more sense and actually output something
- de-duplicate `MongoInstance.kill` code
- actually log output from `mongo_killer` process
- add check that `childProcess.pid` is not undefined before returning from `MongoInstance._launchMongod`
- add custom message if `libcurl4` is missing
- use Environment Variable `Node` before `argv[0]` for `spawnChild`

## Related Issues

- fixes #177 
- maybe fixes #300 
