### PR TITLE
fix(MongoBinaryDownload): print used URL in 404 Error

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -325,7 +325,8 @@ export default class MongoBinaryDownload {
               reject(
                 new Error(
                   "Status Code is 403 (MongoDB's 404)\n" +
-                    "This means that the requested version-platform combination doesn't exist"
+                    "This means that the requested version-platform combination doesn't exist\n" +
+                    `Used Url: "https://${httpOptions.hostname}${httpOptions.path}"`
                 )
               );
               return;


### PR DESCRIPTION
- print the used URL in the Error as well, because issues mostly get reported without debug enabled