### PR TITLE
Fix/various

### DIFF
--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -171,10 +171,8 @@ export default class MongoMemoryReplSet extends EventEmitter {
       return this._initServer(this.getInstanceOpts(opts));
     });
     const cnt = this.opts.replSet.count || 1;
-    /** For extra logging */
-    const current = 0;
     while (servers.length < cnt) {
-      log(`  starting server ${current} of ${cnt}...`);
+      log(`  starting server ${servers.length + 1} of ${cnt}...`);
       const server = this._initServer(this.getInstanceOpts({}));
       servers.push(server);
     }

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -1,11 +1,10 @@
 import { ChildProcess } from 'child_process';
 import * as tmp from 'tmp';
 import getPort from 'get-port';
-import { generateDbName, getUriBase } from './util/db_util';
+import { generateDbName, getUriBase, isNullOrUndefined } from './util/db_util';
 import MongoInstance from './util/MongoInstance';
 import { MongoBinaryOpts } from './util/MongoBinary';
 import { MongoMemoryInstancePropT, StorageEngineT, SpawnOptions } from './types';
-import { isNullOrUndefined } from 'util';
 import debug from 'debug';
 
 const log = debug('MongoMS:MongoMemoryServer');
@@ -217,7 +216,7 @@ export default class MongoMemoryServer {
    * -> throws if instance cannot be started
    */
   async ensureInstance(): Promise<MongoInstanceDataT> {
-    log('Called MongoMemoryServer.ensureInstance() method:');
+    log('Called MongoMemoryServer.ensureInstance() method');
     if (this.runningInstance) {
       return this.runningInstance;
     } else {

--- a/packages/mongodb-memory-server-core/src/__tests__/replset-single-restart-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-single-restart-test.ts
@@ -37,11 +37,12 @@ describe('single-member replica set', () => {
 
     await replSetBefore.stop();
 
-    /**
+    /*
      * get-port has a portlocking-feature that keeps ports locked for
      * "a minimum of 15 seconds and a maximum of 30 seconds before being released again"
      * https://github.com/sindresorhus/get-port#beware
      */
+    // this test needs to use the *exact same port* again, otherwise Mongod will throw an error "No host described in new configuration ${newPort} for replica set testset maps to this node"
     await sleep(30000);
 
     const replSetAfter = new MongoMemoryReplSet(opts);

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -326,7 +326,12 @@ export default class MongoBinaryDownload {
                 new Error(
                   "Status Code is 403 (MongoDB's 404)\n" +
                     "This means that the requested version-platform combination doesn't exist\n" +
-                    `Used Url: "https://${httpOptions.hostname}${httpOptions.path}"`
+                    `  Used Url: "https://${httpOptions.hostname}${httpOptions.path}"\n` +
+                    "Try to use different version 'new MongoMemoryServer({ binary: { version: 'X.Y.Z' } })'\n" +
+                    'List of available versions can be found here:\n' +
+                    '  https://www.mongodb.org/dl/linux for Linux\n' +
+                    '  https://www.mongodb.org/dl/osx for OSX\n' +
+                    '  https://www.mongodb.org/dl/win32 for Windows'
                 )
               );
               return;

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 import resolveConfig from './resolve-config';
 import debug from 'debug';
 import * as semver from 'semver';
-import { isNullOrUndefined } from 'util';
+import { isNullOrUndefined } from './db_util';
 
 const log = debug('MongoMS:MongoBinaryDownloadUrl');
 

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -133,11 +133,11 @@ export default class MongoInstance {
      */
     async function kill_internal(process: ChildProcess, name: string, debug: DebugFn) {
       await new Promise((resolve) => {
-        process.once(`exit`, () => {
-          debug(` - ${name}: got exit signal. Ok!`);
+        process.once(`exit`, (code, signal) => {
+          debug(`- ${name}: got exit signal, Code: ${code}, Signal: ${signal}`);
           resolve();
         });
-        debug(` - ${name}: send kill cmd...`);
+        debug(`- ${name}: send "SIGINT"`);
         process.kill('SIGINT');
       });
     }
@@ -145,13 +145,16 @@ export default class MongoInstance {
     if (this.childProcess && !this.childProcess.killed) {
       await kill_internal(this.childProcess, 'childProcess', this.debug);
     } else {
-      this.debug(' - childProcess: nothing to kill, skipping.');
+      this.debug('- childProcess: nothing to shutdown, skipping.');
     }
     if (this.killerProcess && !this.killerProcess.killed) {
       await kill_internal(this.killerProcess, 'killerProcess', this.debug);
     } else {
-      this.debug(' - killerProcess: nothing to kill, skipping.');
+      this.debug('- killerProcess: nothing to shutdown, skipping.');
     }
+
+    this.debug('Instance Finished Shutdown');
+
     return this;
   }
 

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -2,10 +2,11 @@ import { readFile, readdir } from 'fs';
 import { platform } from 'os';
 
 import { exec } from 'child_process';
-import { promisify, isNullOrUndefined } from 'util';
+import { promisify } from 'util';
 import { join } from 'path';
 import resolveConfig from '../resolve-config';
 import debug from 'debug';
+import { isNullOrUndefined } from '../db_util';
 
 const log = debug('MongoMS:getos');
 


### PR DESCRIPTION
- `MongoMemoryReplSet.start` remove variable `current` because it never got re-assigned
- many files: replace all import of `util.isNullOrUndefined` with `db_util.isNullOrUndefined`
- `MongoMemoryServer.ensureInstance` remove extra `:` in logging
- `replset-single-restart-test`: add extra comment about why to sleep in an test
- `MongoInstance.kill`: change the logging to include code & signal
- `MongoInstance.kill`: add extra logging to note that the instance has finished shutdown
- `MongoBinaryDownload.httpDownload`: extend error to include basic "how to fix"