### PR TITLE
build: remove packages below 4.2 from release

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -50,6 +50,13 @@ module.exports = {
       '@semantic-release/npm',
       {
         npmPublish: true,
+        pkgRoot: './packages/mongodb-memory-server-global-3.6',
+      },
+    ],
+    [
+      '@semantic-release/npm',
+      {
+        npmPublish: true,
         pkgRoot: './packages/mongodb-memory-server-global-4.2',
       },
     ],

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -50,27 +50,6 @@ module.exports = {
       '@semantic-release/npm',
       {
         npmPublish: true,
-        pkgRoot: './packages/mongodb-memory-server-global-3.4',
-      },
-    ],
-    [
-      '@semantic-release/npm',
-      {
-        npmPublish: true,
-        pkgRoot: './packages/mongodb-memory-server-global-3.6',
-      },
-    ],
-    [
-      '@semantic-release/npm',
-      {
-        npmPublish: true,
-        pkgRoot: './packages/mongodb-memory-server-global-4.0',
-      },
-    ],
-    [
-      '@semantic-release/npm',
-      {
-        npmPublish: true,
         pkgRoot: './packages/mongodb-memory-server-global-4.2',
       },
     ],

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Works perfectly [with Travis CI](https://github.com/nodkz/graphql-compose-mongoo
     - [Known Incompatibilities](#known-incompatibilities)
   - [mongodb-memory-server](#mongodb-memory-server)
   - [mongodb-memory-server-global](#mongodb-memory-server-global)
+    - [mongodb-memory-server-global-x.x](#mongodb-memory-server-global-xx)
   - [mongodb-memory-server-core](#mongodb-memory-server-core)
   - [Configuring which mongod binary to use](#configuring-which-mongod-binary-to-use)
 - [Usage](#usage)
@@ -99,6 +100,14 @@ yarn add mongodb-memory-server-global --dev
 # OR
 npm install mongodb-memory-server-global --save-dev
 ```
+
+#### mongodb-memory-server-global-x.x
+
+This Repository provides stub packages that set an MongoDB version, currently availabe are:
+
+`3.4, 3.6, 4.0, 4.2, 4.4`
+
+Note: **The packages below 4.2 have been deprecated**
 
 ### mongodb-memory-server-core
 

--- a/packages/mongodb-memory-server-global-3.4/README.md
+++ b/packages/mongodb-memory-server-global-3.4/README.md
@@ -1,5 +1,7 @@
 # mongodb-memory-server-global-3.4
 
+**Deprecated, please use an version above 4.2**
+
 [![Travis](https://img.shields.io/travis/nodkz/mongodb-memory-server-global-3.4.svg)](https://travis-ci.org/nodkz/mongodb-memory-server-global-3.4)
 [![NPM version](https://img.shields.io/npm/v/mongodb-memory-server-global-3.4.svg)](https://www.npmjs.com/package/mongodb-memory-server-global-3.4)
 [![Downloads stat](https://img.shields.io/npm/dt/mongodb-memory-server-global-3.4.svg)](http://www.npmtrends.com/mongodb-memory-server-global-3.4)

--- a/packages/mongodb-memory-server-global-3.6/README.md
+++ b/packages/mongodb-memory-server-global-3.6/README.md
@@ -1,7 +1,5 @@
 # mongodb-memory-server-global-3.6
 
-**Deprecated, please use an version above 4.2**
-
 [![Travis](https://img.shields.io/travis/nodkz/mongodb-memory-server-global-3.6.svg)](https://travis-ci.org/nodkz/mongodb-memory-server-global-3.6)
 [![NPM version](https://img.shields.io/npm/v/mongodb-memory-server-global-3.6.svg)](https://www.npmjs.com/package/mongodb-memory-server-global-3.6)
 [![Downloads stat](https://img.shields.io/npm/dt/mongodb-memory-server-global-3.6.svg)](http://www.npmtrends.com/mongodb-memory-server-global-3.6)

--- a/packages/mongodb-memory-server-global-3.6/README.md
+++ b/packages/mongodb-memory-server-global-3.6/README.md
@@ -1,5 +1,7 @@
 # mongodb-memory-server-global-3.6
 
+**Deprecated, please use an version above 4.2**
+
 [![Travis](https://img.shields.io/travis/nodkz/mongodb-memory-server-global-3.6.svg)](https://travis-ci.org/nodkz/mongodb-memory-server-global-3.6)
 [![NPM version](https://img.shields.io/npm/v/mongodb-memory-server-global-3.6.svg)](https://www.npmjs.com/package/mongodb-memory-server-global-3.6)
 [![Downloads stat](https://img.shields.io/npm/dt/mongodb-memory-server-global-3.6.svg)](http://www.npmtrends.com/mongodb-memory-server-global-3.6)

--- a/packages/mongodb-memory-server-global-4.0/README.md
+++ b/packages/mongodb-memory-server-global-4.0/README.md
@@ -1,5 +1,7 @@
 # mongodb-memory-server-global-4.0
 
+**Deprecated, please use an version above 4.2**
+
 [![Travis](https://img.shields.io/travis/nodkz/mongodb-memory-server-global-4.0.svg)](https://travis-ci.org/nodkz/mongodb-memory-server-global-4.0)
 [![NPM version](https://img.shields.io/npm/v/mongodb-memory-server-global-4.0.svg)](https://www.npmjs.com/package/mongodb-memory-server-global-4.0)
 [![Downloads stat](https://img.shields.io/npm/dt/mongodb-memory-server-global-4.0.svg)](http://www.npmtrends.com/mongodb-memory-server-global-4.0)


### PR DESCRIPTION
- remove "global-x.x" packages below 4.2 from releases
- README: add deprecation notice

---

This PR removes the packages 3.4, 3.6 and 4.0 from the automated release,
after this pr has been merged the following commands should be run (by @nodkz)
```sh
npm deprecate mongodb-memory-server-global-3.4 "Deprecated, please use an version >= 4.2 (mongodb-memory-server-global-4.2)"
npm deprecate mongodb-memory-server-global-4.0 "Deprecated, please use an version >= 4.2 (mongodb-memory-server-global-4.2)"
```
the commands above will deprecated the entire package (3.4, 3.6, 4.0) with the message provided, this message will show on install and on the npm pages

---

let me know if an message should be updated

PS: if you need an example of a deprecated package, [i once deprecated one](https://www.npmjs.com/package/@hasezoey/typegoose)