### PR TITLE
docs: fix contributing guide location in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ script:
 
 ## Contributing
 
-Contributing Guidelines are setup in [CONTRIBUTING](./..github/CONTRIBUTING.md)
+Contributing Guidelines are setup in [CONTRIBUTING](./.github/CONTRIBUTING.md)
 
 ## Credits
 


### PR DESCRIPTION

- fix location of the contributing guide in readme