### PR TITLE
feat: skip binary download when binary tar exists

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -68,6 +68,7 @@ export default class MongoBinaryDownload {
   async getMongodPath(): Promise<string> {
     const binaryName = this.platform === 'win32' ? 'mongod.exe' : 'mongod';
     const mongodPath = path.resolve(this.downloadDir, this.version, binaryName);
+
     if (await this.locationExists(mongodPath)) {
       return mongodPath;
     }
@@ -99,7 +100,7 @@ export default class MongoBinaryDownload {
     }
 
     const downloadUrl = await mbdUrl.getDownloadUrl();
-    this._downloadingUrl = downloadUrl;
+
     const mongoDBArchive = await this.download(downloadUrl);
 
     await this.makeMD5check(`${downloadUrl}.md5`, mongoDBArchive);
@@ -172,6 +173,14 @@ export default class MongoBinaryDownload {
     const downloadLocation = path.resolve(this.downloadDir, filename);
     const tempDownloadLocation = path.resolve(this.downloadDir, `${filename}.downloading`);
     log(`Downloading${proxy ? ` via proxy ${proxy}` : ''}: "${downloadUrl}"`);
+
+    if (await this.locationExists(downloadLocation)) {
+      log('Already downloaded archive found, skipping download');
+      return downloadLocation;
+    }
+
+    this._downloadingUrl = downloadUrl;
+
     const downloadedFile = await this.httpDownload(
       downloadOptions,
       downloadLocation,

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload-test.ts
@@ -32,11 +32,22 @@ MONGOMS_MD5_CHECK environment variable`, () => {
 
     const du = new MongoBinaryDownload({});
     du.httpDownload = jest.fn();
+    du.locationExists = jest.fn().mockReturnValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);
     const callArg1 = (du.httpDownload as jest.Mock).mock.calls[0][0];
     expect(callArg1.agent).toBeUndefined();
+  });
+
+  it('should skip download if binary tar exists', async () => {
+    const du = new MongoBinaryDownload({});
+    du.httpDownload = jest.fn();
+    du.locationExists = jest.fn().mockReturnValue(true);
+
+    await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
+
+    expect(du.httpDownload).not.toHaveBeenCalled();
   });
 
   it('should pick up proxy from env vars', async () => {
@@ -45,6 +56,7 @@ MONGOMS_MD5_CHECK environment variable`, () => {
     const du = new MongoBinaryDownload({});
     // $FlowFixMe
     du.httpDownload = jest.fn();
+    du.locationExists = jest.fn().mockReturnValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);
@@ -59,6 +71,7 @@ MONGOMS_MD5_CHECK environment variable`, () => {
 
     const du = new MongoBinaryDownload({});
     du.httpDownload = jest.fn();
+    du.locationExists = jest.fn().mockReturnValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);
@@ -73,6 +86,7 @@ MONGOMS_MD5_CHECK environment variable`, () => {
 
     const du = new MongoBinaryDownload({});
     du.httpDownload = jest.fn();
+    du.locationExists = jest.fn().mockReturnValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
- Added check to skip binary tar download, if the required tar is already present in the location

## Related Issues
- closes #303 
