### PR TITLE
explicitly export default from mms

### DIFF
--- a/packages/mongodb-memory-server-global-3.4/index.js
+++ b/packages/mongodb-memory-server-global-3.4/index.js
@@ -1,6 +1,9 @@
 'use strict';
 function __export(m) {
-  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  for (var p in m) {
+    if (p === "default") exports.default = m[p];
+    if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  }
 }
 
 var setDefaultValue = require('../mongodb-memory-server-core/lib/util/resolve-config')

--- a/packages/mongodb-memory-server-global-3.6/index.js
+++ b/packages/mongodb-memory-server-global-3.6/index.js
@@ -1,6 +1,9 @@
 'use strict';
 function __export(m) {
-  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  for (var p in m) {
+   if (p === "default") exports.default = m[p];
+   if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  }
 }
 
 var setDefaultValue = require('../mongodb-memory-server-core/lib/util/resolve-config')

--- a/packages/mongodb-memory-server-global-4.0/index.js
+++ b/packages/mongodb-memory-server-global-4.0/index.js
@@ -1,6 +1,9 @@
 'use strict';
 function __export(m) {
-  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  for (var p in m) {
+    if (p === "default") exports.default = m[p];
+    if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  }
 }
 
 var setDefaultValue = require('../mongodb-memory-server-core/lib/util/resolve-config')

--- a/packages/mongodb-memory-server-global-4.2/index.js
+++ b/packages/mongodb-memory-server-global-4.2/index.js
@@ -1,6 +1,9 @@
 'use strict';
 function __export(m) {
-  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  for (var p in m) {
+    if (p === "default") exports.default = m[p];
+    if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  }
 }
 
 var setDefaultValue = require('../mongodb-memory-server-core/lib/util/resolve-config')

--- a/packages/mongodb-memory-server-global-4.4/index.js
+++ b/packages/mongodb-memory-server-global-4.4/index.js
@@ -1,6 +1,9 @@
 'use strict';
 function __export(m) {
-  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  for (var p in m) {
+    if (p === "default") exports.default = m[p];
+    if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  }
 }
 
 var setDefaultValue = require('../mongodb-memory-server-core/lib/util/resolve-config')

--- a/packages/mongodb-memory-server-global/index.js
+++ b/packages/mongodb-memory-server-global/index.js
@@ -1,6 +1,9 @@
 'use strict';
 function __export(m) {
-  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  for (var p in m) {
+    if (p === "default") exports.default = m[p];
+    if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  }
 }
 Object.defineProperty(exports, '__esModule', { value: true });
 __export(require('mongodb-memory-server-core'));

--- a/packages/mongodb-memory-server/index.js
+++ b/packages/mongodb-memory-server/index.js
@@ -1,6 +1,9 @@
 'use strict';
 function __export(m) {
-  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  for (var p in m) {
+		if (p === "default") exports.default = m[p];
+    if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+  }
 }
 Object.defineProperty(exports, '__esModule', { value: true });
 __export(require('mongodb-memory-server-core'));


### PR DESCRIPTION
This line explicitly exports `exports default` - mongoMemoryServer - received from require.
`if (p === "default") exports.default = m[p];`
