### PR TITLE
Fix/385

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     }
   },
   "scripts": {
-    "test": "lerna run test --stream",
+    "test": "yarn --cwd packages/mongodb-memory-server-core run test",
     "lint": "lerna run lint --stream --npm-client=yarn --no-prefix",
     "eslint": "eslint 'packages/mongodb-memory-server-core/src/**/*.{js,ts}'",
     "watch": "jest --env node --watch",

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -119,11 +119,11 @@ export default class MongoInstance {
     const launch = new Promise((resolve, reject) => {
       this.instanceReady = () => {
         this.isInstanceReady = true;
-        this.debug('MongodbInstance: is ready!');
+        this.debug('MongodbInstance: Instance is ready!');
         resolve({ ...this.childProcess });
       };
       this.instanceFailed = (err: any) => {
-        this.debug(`MongodbInstance: is failed: ${err.toString()}`);
+        this.debug(`MongodbInstance: Instance has failed: ${err.toString()}`);
         if (this.killerProcess) {
           this.killerProcess.kill();
         }

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -125,7 +125,7 @@ describe('MongodbInstance', () => {
       binary: { version: LATEST_VERSION },
     });
     const pid: any = mongod.getPid();
-    const killerPid: any = mongod.killerProcess && mongod.killerProcess.pid;
+    const killerPid: any = mongod.killerProcess?.pid;
     expect(pid).toBeGreaterThan(0);
     expect(killerPid).toBeGreaterThan(0);
 


### PR DESCRIPTION
- add an call to "instanceFailed" into "closeHandler" to ensure the "launch" promise resolves
- add an timeout to "kill_internal"
- always call "kill_internal" if the childprocess's are defined
- convert one line to optional-chaining
- call the only test script in the whole repo directly in the root package
- fix spelling in logs in function "run"

## Related Issues

- fixes #385