### PR TITLE
fix/improveMongoInstance

### DIFF
--- a/packages/mongodb-memory-server-core/src/__tests__/replset-multi-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-multi-test.ts
@@ -5,8 +5,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 
 describe('multi-member replica set', () => {
   it('should enter running state', async () => {
-    const opts: any = { replSet: { count: 3 } };
-    const replSet = new MongoMemoryReplSet(opts);
+    const replSet = new MongoMemoryReplSet({ replSet: { count: 3 } });
     await replSet.waitUntilRunning();
     expect(replSet.servers.length).toEqual(3);
     const uri = await replSet.getUri();
@@ -16,8 +15,7 @@ describe('multi-member replica set', () => {
   }, 40000);
 
   it('should be possible to connect replicaset after waitUntilRunning resolveds', async () => {
-    const opts: any = { replSet: { count: 3 } };
-    const replSet = new MongoMemoryReplSet(opts);
+    const replSet = new MongoMemoryReplSet({ replSet: { count: 3 } });
     await replSet.waitUntilRunning();
     const uri = await replSet.getUri();
 

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -67,8 +67,8 @@ export default class MongoInstance extends EventEmitter {
   binaryOpts: MongoBinaryOpts;
   spawnOpts: SpawnOptions;
 
-  childProcess: ChildProcess | null = null;
-  killerProcess: ChildProcess | null = null;
+  childProcess?: ChildProcess;
+  killerProcess?: ChildProcess;
   isInstancePrimary: boolean = false;
   isInstanceReady: boolean = false;
 

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -179,11 +179,13 @@ export default class MongoInstance extends EventEmitter {
 
     if (!isNullOrUndefined(this.childProcess)) {
       await killProcess(this.childProcess, 'childProcess');
+      this.childProcess = undefined; // reset reference to the childProcess for "mongod"
     } else {
       this.debug('- childProcess: nothing to shutdown, skipping.');
     }
     if (!isNullOrUndefined(this.killerProcess)) {
       await killProcess(this.killerProcess, 'killerProcess');
+      this.killerProcess = undefined; // reset reference to the childProcess for "mongo_killer"
     } else {
       this.debug('- killerProcess: nothing to shutdown, skipping.');
     }

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -20,7 +20,7 @@ if (lt(process.version, '10.15.0')) {
 
 const log = debug('MongoMS:MongoInstance');
 
-export interface MongodOps {
+export interface MongodOpts {
   // instance options
   instance: {
     port?: number;
@@ -44,7 +44,7 @@ export interface MongodOps {
  */
 export default class MongoInstance {
   static childProcessList: ChildProcess[] = [];
-  opts: MongodOps;
+  opts: MongodOpts;
   debug: DebugFn;
 
   childProcess: ChildProcess | null;
@@ -55,7 +55,7 @@ export default class MongoInstance {
   instanceReady: EmptyVoidCallback = () => {};
   instanceFailed: ErrorVoidCallback = () => {};
 
-  constructor(opts: MongodOps) {
+  constructor(opts: MongodOpts) {
     this.opts = opts;
     this.childProcess = null;
     this.killerProcess = null;
@@ -83,7 +83,7 @@ export default class MongoInstance {
    * Create an new instance an call method "run"
    * @param opts Options passed to the new instance
    */
-  static async run(opts: MongodOps): Promise<MongoInstance> {
+  static async run(opts: MongodOpts): Promise<MongoInstance> {
     const instance = new this(opts);
     return instance.run();
   }

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -59,7 +59,6 @@ export default class MongoInstance extends EventEmitter {
 
   childProcess: ChildProcess | null = null;
   killerProcess: ChildProcess | null = null;
-  waitForPrimaryResolveFns: ((value: boolean) => void)[] = [];
   isInstancePrimary: boolean = false;
   isInstanceReady: boolean = false;
   instanceReady: EmptyVoidCallback = () => {};
@@ -210,18 +209,6 @@ export default class MongoInstance extends EventEmitter {
   }
 
   /**
-   * Wait until mongod has elected an Primary
-   */
-  async waitPrimaryReady(): Promise<boolean> {
-    if (this.isInstancePrimary) {
-      return true;
-    }
-    return new Promise((resolve) => {
-      this.waitForPrimaryResolveFns.push(resolve);
-    });
-  }
-
-  /**
    * Actually launch mongod
    * @param mongoBin The binary to run
    */
@@ -353,7 +340,6 @@ export default class MongoInstance extends EventEmitter {
       this.isInstancePrimary = true;
       this.debug('Calling all waitForPrimary resolve functions');
       this.emit(MongoInstanceEvents.instancePrimary);
-      this.waitForPrimaryResolveFns.forEach((resolveFn) => resolveFn(true));
     } else if (/member [\d\.:]+ is now in state \w+/i.test(line)) {
       const state = /member [\d\.:]+ is now in state (\w+)/i.exec(line)?.[1] ?? 'UNKOWN';
       this.emit(MongoInstanceEvents.instanceState, state);

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -52,6 +52,13 @@ export interface MongodOpts {
   spawn: SpawnOptions;
 }
 
+export default interface MongoInstance extends EventEmitter {
+  // Overwrite EventEmitter's definitions (to provide at least the event names)
+  emit(event: MongoInstanceEvents, ...args: any[]): boolean;
+  on(event: MongoInstanceEvents, listener: (...args: any[]) => void): this;
+  once(event: MongoInstanceEvents, listener: (...args: any[]) => void): this;
+}
+
 /**
  * MongoDB Instance Handler Class
  */

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -39,26 +39,16 @@ export interface MongodOpts {
 export default class MongoInstance {
   opts: MongodOpts;
 
-  childProcess: ChildProcess | null;
-  killerProcess: ChildProcess | null;
-  waitForPrimaryResolveFns: ((value: boolean) => void)[];
+  childProcess: ChildProcess | null = null;
+  killerProcess: ChildProcess | null = null;
+  waitForPrimaryResolveFns: ((value: boolean) => void)[] = [];
   isInstancePrimary: boolean = false;
   isInstanceReady: boolean = false;
   instanceReady: EmptyVoidCallback = () => {};
   instanceFailed: ErrorVoidCallback = () => {};
 
   constructor(opts: MongodOpts) {
-    this.opts = opts;
-    this.childProcess = null;
-    this.killerProcess = null;
-    this.waitForPrimaryResolveFns = [];
-
-    if (!this.opts.instance) {
-      this.opts.instance = {};
-    }
-    if (!this.opts.binary) {
-      this.opts.binary = {};
-    }
+    this.opts = Object.assign({ binary: {}, instance: {}, spawn: {} } as MongodOpts, opts);
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -97,10 +97,8 @@ export default class MongoInstance extends EventEmitter {
    * @param msg The Message to log
    */
   private debug(msg: string): void {
-    if (debug.enabled('MongoMS:MongoInstance')) {
-      const port = this.instanceOpts.port ?? 'unkown';
-      log(`Mongo[${port}]: ${msg}`);
-    }
+    const port = this.instanceOpts.port ?? 'unkown';
+    log(`Mongo[${port}]: ${msg}`);
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -168,10 +168,10 @@ export default class MongoInstance extends EventEmitter {
 
     /**
      * Function to De-Duplicate Code
-     * @param process The Process to kill
+     * @param childprocess The Process to kill
      * @param name the name used in the logs
      */
-    async function kill_internal(this: MongoInstance, process: ChildProcess, name: string) {
+    async function kill_internal(this: MongoInstance, childprocess: ChildProcess, name: string) {
       const timeoutTime = 1000 * 10;
       await new Promise((resolve, reject) => {
         let timeout = setTimeout(() => {
@@ -182,19 +182,19 @@ export default class MongoInstance extends EventEmitter {
                 'Enable debug logs for more information'
             );
           }
-          process.kill('SIGKILL');
+          childprocess.kill('SIGKILL');
           timeout = setTimeout(() => {
             this.debug('kill_internal timeout triggered again, rejecting');
             reject(new Error('Process didnt exit, enable debug for more information.'));
           }, timeoutTime);
         }, timeoutTime);
-        process.once(`exit`, (code, signal) => {
+        childprocess.once(`exit`, (code, signal) => {
           this.debug(`- ${name}: got exit signal, Code: ${code}, Signal: ${signal}`);
           clearTimeout(timeout);
           resolve();
         });
         this.debug(`- ${name}: send "SIGINT"`);
-        process.kill('SIGINT');
+        childprocess.kill('SIGINT');
       });
     }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -14,17 +14,19 @@ if (lt(process.version, '10.15.0')) {
 
 const log = debug('MongoMS:MongoInstance');
 
+export interface MongoInstanceOpts {
+  port?: number;
+  ip?: string; // for binding to all IP addresses set it to `::,0.0.0.0`, by default '127.0.0.1'
+  storageEngine?: StorageEngineT;
+  dbPath?: string;
+  replSet?: string;
+  args?: string[];
+  auth?: boolean;
+}
+
 export interface MongodOpts {
   // instance options
-  instance: {
-    port?: number;
-    ip?: string; // for binding to all IP addresses set it to `::,0.0.0.0`, by default '127.0.0.1'
-    storageEngine?: StorageEngineT;
-    dbPath?: string;
-    replSet?: string;
-    args?: string[];
-    auth?: boolean;
-  };
+  instance: MongoInstanceOpts;
 
   // mongo binary options
   binary?: MongoBinaryOpts;

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -129,6 +129,9 @@ export default class MongoInstance {
     return this;
   }
 
+  /**
+   * Shutdown all related processes (Mongod Instance & Killer Process)
+   */
   async kill(): Promise<MongoInstance> {
     this.debug('Called MongoInstance.kill():');
 
@@ -257,13 +260,17 @@ export default class MongoInstance {
     return killer;
   }
 
+  /**
+   * Event "error" handler
+   * @param err The Error to handle
+   */
   errorHandler(err: string): void {
     this.instanceFailed(err);
   }
 
   /**
    * Write the CLOSE event to the debug function
-   * @param code The Exit code
+   * @param code The Exit code to handle
    */
   closeHandler(code: number): void {
     if (code != 0) {

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -153,6 +153,7 @@ export default class MongoInstance extends EventEmitter {
 
   /**
    * Create the mongod process
+   * @fires MongoInstance#instanceStarted
    */
   async run(): Promise<this> {
     const launch: Promise<void> = new Promise((resolve, reject) => {
@@ -204,6 +205,7 @@ export default class MongoInstance extends EventEmitter {
   /**
    * Actually launch mongod
    * @param mongoBin The binary to run
+   * @fires MongoInstance#instanceLaunched
    */
   _launchMongod(mongoBin: string): ChildProcess {
     const childProcess = spawnChild(mongoBin, this.prepareCommandArgs(), {
@@ -228,6 +230,7 @@ export default class MongoInstance extends EventEmitter {
    * Spawn an child to kill the parent and the mongod instance if both are Dead
    * @param parentPid Parent to kill
    * @param childPid Mongod process to kill
+   * @fires MongoInstance#killerLaunched
    */
   _launchKiller(parentPid: number, childPid: number): ChildProcess {
     this.debug(`Called MongoInstance._launchKiller(parent: ${parentPid}, child: ${childPid}):`);
@@ -264,6 +267,8 @@ export default class MongoInstance extends EventEmitter {
   /**
    * Event "error" handler
    * @param err The Error to handle
+   * @fires MongoInstance#instanceRawError
+   * @fires MongoInstance#instanceError
    */
   errorHandler(err: string): void {
     this.emit(MongoInstanceEvents.instanceRawError, err);
@@ -273,6 +278,7 @@ export default class MongoInstance extends EventEmitter {
   /**
    * Write the CLOSE event to the debug function
    * @param code The Exit code to handle
+   * @fires MongoInstance#instanceClosed
    */
   closeHandler(code: number): void {
     if (code != 0) {
@@ -285,6 +291,7 @@ export default class MongoInstance extends EventEmitter {
   /**
    * Write STDERR to debug function
    * @param message The STDERR line to write
+   * @fires MongoInstance#instanceSTDERR
    */
   stderrHandler(message: string | Buffer): void {
     this.debug(`STDERR: ${message.toString()}`);
@@ -294,6 +301,11 @@ export default class MongoInstance extends EventEmitter {
   /**
    * Write STDOUT to debug function and process some special messages
    * @param message The STDOUT line to write/parse
+   * @fires MongoInstance#instanceSTDOUT
+   * @fires MongoInstance#instanceReady
+   * @fires MongoInstance#instanceError
+   * @fires MongoInstance#instancePrimary
+   * @fires MongoInstance#instanceState
    */
   stdoutHandler(message: string | Buffer): void {
     const line: string = message.toString();

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -194,7 +194,7 @@ export default class MongoInstance {
   }
 
   /**
-   * Wait until the Primary mongod is running
+   * Wait until mongod has elected an Primary
    */
   async waitPrimaryReady(): Promise<boolean> {
     if (this.isInstancePrimary) {

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -109,6 +109,7 @@ export default class MongoInstance extends EventEmitter {
    * Create an array of arguments for the mongod instance
    */
   prepareCommandArgs(): string[] {
+    this.debug('prepareCommandArgs');
     assertion(
       !isNullOrUndefined(this.instanceOpts.port),
       new Error('"instanceOpts.port" is required to be set!')
@@ -136,7 +137,11 @@ export default class MongoInstance extends EventEmitter {
       result.push('--replSet', this.instanceOpts.replSet);
     }
 
-    return result.concat(this.instanceOpts.args ?? []);
+    const final = result.concat(this.instanceOpts.args ?? []);
+
+    this.debug('prepareCommandArgs: final arugment array:' + JSON.stringify(final));
+
+    return final;
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -81,29 +81,28 @@ export default class MongoInstance {
    * Create an array of arguments for the mongod instance
    */
   prepareCommandArgs(): string[] {
-    const { ip, port, storageEngine, dbPath, replSet, auth, args } = this.instanceOpts;
-
     const result: string[] = [];
-    result.push('--bind_ip', ip || '127.0.0.1'); // default on all falsy values
-    if (port) {
-      result.push('--port', port.toString());
+    result.push('--bind_ip', this.instanceOpts.ip || '127.0.0.1'); // default on all falsy values
+    // "!!" converts the value to an boolean (double-invert) so that no "falsy" values are added
+    if (!!this.instanceOpts.port) {
+      result.push('--port', this.instanceOpts.port.toString());
     }
-    if (storageEngine) {
-      result.push('--storageEngine', storageEngine);
+    if (!!this.instanceOpts.storageEngine) {
+      result.push('--storageEngine', this.instanceOpts.storageEngine);
     }
-    if (dbPath) {
-      result.push('--dbpath', dbPath);
+    if (!!this.instanceOpts.dbPath) {
+      result.push('--dbpath', this.instanceOpts.dbPath);
     }
-    if (!auth) {
-      result.push('--noauth');
-    } else if (auth) {
+    if (this.instanceOpts.auth) {
       result.push('--auth');
+    } else {
+      result.push('--noauth');
     }
-    if (replSet) {
-      result.push('--replSet', replSet);
+    if (!!this.instanceOpts.replSet) {
+      result.push('--replSet', this.instanceOpts.replSet);
     }
 
-    return result.concat(args ?? []);
+    return result.concat(this.instanceOpts.args ?? []);
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -29,10 +29,10 @@ export interface MongodOpts {
   instance: MongoInstanceOpts;
 
   // mongo binary options
-  binary?: MongoBinaryOpts;
+  binary: MongoBinaryOpts;
 
   // child process spawn options
-  spawn?: SpawnOptions;
+  spawn: SpawnOptions;
 }
 
 /**
@@ -49,7 +49,7 @@ export default class MongoInstance {
   instanceReady: EmptyVoidCallback = () => {};
   instanceFailed: ErrorVoidCallback = () => {};
 
-  constructor(opts: MongodOpts) {
+  constructor(opts: Partial<MongodOpts>) {
     this.opts = Object.assign({ binary: {}, instance: {}, spawn: {} } as MongodOpts, opts);
   }
 
@@ -68,7 +68,7 @@ export default class MongoInstance {
    * Create an new instance an call method "run"
    * @param opts Options passed to the new instance
    */
-  static async run(opts: MongodOpts): Promise<MongoInstance> {
+  static async run(opts: Partial<MongodOpts>): Promise<MongoInstance> {
     const instance = new this(opts);
     return instance.run();
   }

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -43,7 +43,6 @@ export interface MongodOpts {
  * MongoDB Instance Handler Class
  */
 export default class MongoInstance {
-  static childProcessList: ChildProcess[] = [];
   opts: MongodOpts;
   debug: DebugFn;
 

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -61,15 +61,28 @@ export default interface MongoInstance extends EventEmitter {
 
 /**
  * MongoDB Instance Handler Class
+ * This Class starts & stops the "mongod" process directly and handles stdout, sterr and close events
  */
 export default class MongoInstance extends EventEmitter {
   instanceOpts: MongoInstanceOpts;
   binaryOpts: MongoBinaryOpts;
   spawnOpts: SpawnOptions;
 
+  /**
+   * The "mongod" Process reference
+   */
   childProcess?: ChildProcess;
+  /**
+   * The "mongo_killer" Process reference
+   */
   killerProcess?: ChildProcess;
+  /**
+   * This boolean is "true" if the instance is elected to be PRIMARY
+   */
   isInstancePrimary: boolean = false;
+  /**
+   * This boolean is "true" if the instance is successfully started
+   */
   isInstanceReady: boolean = false;
 
   constructor(opts: Partial<MongodOpts>) {

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -80,7 +80,7 @@ export default class MongoInstance {
     const { ip, port, storageEngine, dbPath, replSet, auth, args } = this.opts.instance;
 
     const result: string[] = [];
-    result.push('--bind_ip', ip || '127.0.0.1');
+    result.push('--bind_ip', ip || '127.0.0.1'); // default on all falsy values
     if (port) {
       result.push('--port', port.toString());
     }
@@ -106,11 +106,11 @@ export default class MongoInstance {
    * Create the mongod process
    */
   async run(): Promise<this> {
-    const launch = new Promise((resolve, reject) => {
+    const launch: Promise<void> = new Promise((resolve, reject) => {
       this.instanceReady = () => {
         this.isInstanceReady = true;
         this.debug('MongodbInstance: Instance is ready!');
-        resolve({ ...this.childProcess });
+        resolve();
       };
       this.instanceFailed = (err: any) => {
         this.debug(`MongodbInstance: Instance has failed: ${err.toString()}`);

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -16,7 +16,7 @@ if (lt(process.version, '10.15.0')) {
 const log = debug('MongoMS:MongoInstance');
 
 export enum MongoInstanceEvents {
-  instanceState = 'instanceState',
+  instanceReplState = 'instanceReplState',
   instancePrimary = 'instancePrimary',
   instanceReady = 'instanceReady',
   instanceSTDOUT = 'instanceSTDOUT',
@@ -303,7 +303,7 @@ export default class MongoInstance extends EventEmitter {
    * @fires MongoInstance#instanceReady
    * @fires MongoInstance#instanceError
    * @fires MongoInstance#instancePrimary
-   * @fires MongoInstance#instanceState
+   * @fires MongoInstance#instanceReplState
    */
   stdoutHandler(message: string | Buffer): void {
     const line: string = message.toString();
@@ -341,7 +341,7 @@ export default class MongoInstance extends EventEmitter {
     } else if (/member [\d\.:]+ is now in state \w+/i.test(line)) {
       // "[\d\.:]+" matches "0.0.0.0:0000" (IP:PORT)
       const state = /member [\d\.:]+ is now in state (\w+)/i.exec(line)?.[1] ?? 'UNKOWN';
-      this.emit(MongoInstanceEvents.instanceState, state);
+      this.emit(MongoInstanceEvents.instanceReplState, state);
 
       if (state !== 'PRIMARY') {
         this.isInstancePrimary = false;

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -290,6 +290,20 @@ describe('MongodbInstance', () => {
         expect(events.get(MongoInstanceEvents.instancePrimary)).toEqual(undefined);
         expect(mongod.isInstancePrimary).toEqual(true);
       });
+
+      it('should emit "instanceState" when member state is changed', () => {
+        // actual line copied from mongod 4.0.14
+        const line =
+          'STDOUT: 2020-09-30T19:41:48.388+0200 I REPL     [replexec-0] Member 127.0.0.1:34765 is now in state STARTUP';
+
+        mongod.isInstancePrimary = true;
+        mongod.stdoutHandler(line);
+
+        expect(events.size).toEqual(2);
+        expect(events.get(MongoInstanceEvents.instanceSTDOUT)).toEqual(line);
+        expect(events.get(MongoInstanceEvents.instanceState)).toEqual('STARTUP');
+        expect(mongod.isInstancePrimary).toEqual(false);
+      });
     });
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -114,7 +114,7 @@ describe('MongodbInstance', () => {
         instance: { port: 27444, dbPath: tmpDir.name },
         binary: { version: LATEST_VERSION },
       })
-    ).rejects.toBeDefined();
+    ).rejects.toEqual('Port 27444 already in use');
 
     await mongod.kill();
   });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -24,14 +24,12 @@ describe('MongodbInstance', () => {
       },
     });
     expect(inst.prepareCommandArgs()).toEqual([
-      '--bind_ip',
-      '127.0.0.1',
       '--port',
       '27333',
-      '--storageEngine',
-      'ephemeralForTest',
       '--dbpath',
       tmpDir.name,
+      '--storageEngine',
+      'ephemeralForTest',
       '--noauth',
     ]);
   });
@@ -45,8 +43,6 @@ describe('MongodbInstance', () => {
       },
     });
     expect(inst.prepareCommandArgs()).toEqual([
-      '--bind_ip',
-      '127.0.0.1',
       '--port',
       '27555',
       '--dbpath',
@@ -66,8 +62,6 @@ describe('MongodbInstance', () => {
       },
     });
     expect(inst.prepareCommandArgs()).toEqual([
-      '--bind_ip',
-      '127.0.0.1',
       '--port',
       '27555',
       '--dbpath',
@@ -86,10 +80,36 @@ describe('MongodbInstance', () => {
       },
     });
     expect(inst.prepareCommandArgs()).toEqual(
-      ['--bind_ip', '127.0.0.1', '--port', '27555', '--dbpath', tmpDir.name, '--noauth'].concat(
-        args
-      )
+      ['--port', '27555', '--dbpath', tmpDir.name, '--noauth'].concat(args)
     );
+  });
+
+  it('should throw an error if no port is provided', () => {
+    const inst = new MongodbInstance({
+      instance: {
+        dbPath: tmpDir.name,
+      },
+    });
+    try {
+      inst.prepareCommandArgs();
+      fail('Expected prepareCommandArgs to throw');
+    } catch (err) {
+      expect(err.message).toEqual('"instanceOpts.port" is required to be set!');
+    }
+  });
+
+  it('should throw an error if no dbpath is provided', () => {
+    const inst = new MongodbInstance({
+      instance: {
+        port: 27555,
+      },
+    });
+    try {
+      inst.prepareCommandArgs();
+      fail('Expected prepareCommandArgs to throw');
+    } catch (err) {
+      expect(err.message).toEqual('"instanceOpts.dbPath" is required to be set!');
+    }
   });
 
   it('should start instance on port 27333', async () => {

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -119,7 +119,7 @@ describe('MongodbInstance', () => {
     await mongod.kill();
   });
 
-  it('should await while mongo is killed', async () => {
+  it('should wait until childprocess and killerprocess are killed', async () => {
     const mongod: MongodbInstance = await MongodbInstance.run({
       instance: { port: 27445, dbPath: tmpDir.name },
       binary: { version: LATEST_VERSION },

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -223,4 +223,25 @@ describe('MongodbInstance', () => {
     expect(events.size).toEqual(1);
     expect(events.get(MongoInstanceEvents.instanceSTDERR)).toEqual('hello');
   });
+
+  describe('stdoutHandler()', () => {
+    it('should emit "instanceReady" when waiting for connections', () => {
+      const mongod = new MongodbInstance({});
+      const events: Map<MongoInstanceEvents | string, string> = new Map();
+      jest.spyOn(mongod, 'emit').mockImplementation((event: string, arg1: string) => {
+        events.set(event, arg1);
+        return true;
+      });
+
+      // actual line copied from mongod 4.0.14
+      const line =
+        '2020-09-30T18:48:58.273+0200 I NETWORK  [initandlisten] waiting for connections on port 45227';
+
+      mongod.stdoutHandler(line);
+
+      expect(events.size).toEqual(2);
+      expect(events.get(MongoInstanceEvents.instanceSTDOUT)).toEqual(line);
+      expect(events.get(MongoInstanceEvents.instanceReady)).toEqual(undefined);
+    });
+  });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -1,7 +1,7 @@
 import * as tmp from 'tmp';
 import * as dbUtil from '../db_util';
 import { LATEST_VERSION } from '../MongoBinary';
-import MongodbInstance from '../MongoInstance';
+import MongodbInstance, { MongoInstanceEvents } from '../MongoInstance';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 tmp.setGracefulCleanup();
@@ -193,5 +193,20 @@ describe('MongodbInstance', () => {
     } catch (err) {
       expect(err.message).toEqual('Spawned Mongo Instance PID is undefined');
     }
+  });
+
+  it('"errorHandler" should emit "instanceRawError" and "instanceError"', () => {
+    const mongod = new MongodbInstance({});
+    const events: Map<MongoInstanceEvents | string, string> = new Map();
+    jest.spyOn(mongod, 'emit').mockImplementation((event: string, arg1: string) => {
+      events.set(event, arg1);
+      return true;
+    });
+
+    mongod.errorHandler('hello');
+
+    expect(events.size).toEqual(2);
+    expect(events.get(MongoInstanceEvents.instanceRawError)).toEqual('hello');
+    expect(events.get(MongoInstanceEvents.instanceError)).toEqual('hello');
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -224,6 +224,11 @@ describe('MongodbInstance', () => {
     describe('stdoutHandler()', () => {
       // All the lines used to test here should be sourced from actual mongod output!
 
+      // TODO: add test for "mongod instance already running"
+      // TODO: add test for "permission denied"
+      // TODO: add test for "Data directory .*? not found"
+      // TODO: add test for "aborting after"
+
       it('should emit "instanceReady" when waiting for connections', () => {
         // actual line copied from mongod 4.0.14
         const line =

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -296,7 +296,7 @@ describe('MongodbInstance', () => {
         expect(mongod.isInstancePrimary).toEqual(true);
       });
 
-      it('should emit "instanceState" when member state is changed', () => {
+      it('should emit "instanceReplState" when member state is changed', () => {
         // actual line copied from mongod 4.0.14
         const line =
           'STDOUT: 2020-09-30T19:41:48.388+0200 I REPL     [replexec-0] Member 127.0.0.1:34765 is now in state STARTUP';
@@ -306,7 +306,7 @@ describe('MongodbInstance', () => {
 
         expect(events.size).toEqual(2);
         expect(events.get(MongoInstanceEvents.instanceSTDOUT)).toEqual(line);
-        expect(events.get(MongoInstanceEvents.instanceState)).toEqual('STARTUP');
+        expect(events.get(MongoInstanceEvents.instanceReplState)).toEqual('STARTUP');
         expect(mongod.isInstancePrimary).toEqual(false);
       });
     });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -250,6 +250,21 @@ describe('MongodbInstance', () => {
         expect(events.get(MongoInstanceEvents.instanceSTDOUT)).toEqual(line);
         expect(events.get(MongoInstanceEvents.instanceError)).toEqual('Port 1001 already in use');
       });
+
+      it('should emit "instanceError" when curl-open-ssl-3 is not found', () => {
+        // actual line copied from mongod 4.0.3 (from https://github.com/nodkz/mongodb-memory-server/issues/204#issuecomment-514492136)
+        const line =
+          "/fm/fm-api/node_modules/.cache/mongodb-memory-server/mongodb-binaries/4.0.3/mongod: /usr/lib/x86_64-linux-gnu/libcurl.so.4: version 'CURL_OPENSSL_3' not found (required by /fm/fm-api/node_modules/.cache/mongodb-memory-server/mongodb-binaries/4.0.3/mongod)";
+
+        mongod.stdoutHandler(line);
+
+        expect(events.size).toEqual(2);
+        expect(events.get(MongoInstanceEvents.instanceSTDOUT)).toEqual(line);
+        expect(events.get(MongoInstanceEvents.instanceError)).toEqual(
+          'libcurl3 is not available on your system. Mongod requires it and cannot be started without it.\n' +
+            'You should manually install libcurl3 or try to use an newer version of MongoDB\n'
+        );
+      });
     });
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -183,4 +183,15 @@ describe('MongodbInstance', () => {
 
     expect(dbUtil.killProcess).not.toBeCalled();
   });
+
+  it('"_launchMongod" should throw an error if "childProcess.pid" is undefined', () => {
+    const mongod = new MongodbInstance({ instance: { port: 0, dbPath: '' } }); // dummy values - they shouldnt matter
+
+    try {
+      mongod._launchMongod('thisShouldNotExist');
+      fail('Expected "_launchMongod" to throw');
+    } catch (err) {
+      expect(err.message).toEqual('Spawned Mongo Instance PID is undefined');
+    }
+  });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -227,6 +227,8 @@ describe('MongodbInstance', () => {
     });
 
     describe('stdoutHandler()', () => {
+      // All the lines used to test here should be sourced from actual mongod output!
+
       it('should emit "instanceReady" when waiting for connections', () => {
         // actual line copied from mongod 4.0.14
         const line =
@@ -263,6 +265,21 @@ describe('MongodbInstance', () => {
         expect(events.get(MongoInstanceEvents.instanceError)).toEqual(
           'libcurl3 is not available on your system. Mongod requires it and cannot be started without it.\n' +
             'You should manually install libcurl3 or try to use an newer version of MongoDB\n'
+        );
+      });
+
+      it('should emit "instanceError" when curl-open-ssl-4 is not found', () => {
+        // actual line copied from mongod 4.0.14 (from https://github.com/nodkz/mongodb-memory-server/issues/313#issue-631429207)
+        const line =
+          "/usr/src/app/packages/backend/node_modules/.cache/mongodb-memory-server/mongodb-binaries/4.0.14/mongod: /usr/lib/x86_64-linux-gnu/libcurl.so.4: version `CURL_OPENSSL_4' not found (required by /usr/src/app/packages/backend/node_modules/.cache/mongodb-memory-server/mongodb-binaries/4.0.14/mongod)";
+
+        mongod.stdoutHandler(line);
+
+        expect(events.size).toEqual(2);
+        expect(events.get(MongoInstanceEvents.instanceSTDOUT)).toEqual(line);
+        expect(events.get(MongoInstanceEvents.instanceError)).toEqual(
+          'libcurl4 is not available on your system. Mongod requires it and cannot be started without it.\n' +
+            'You need to manually install libcurl4\n'
         );
       });
     });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -1,4 +1,5 @@
 import * as tmp from 'tmp';
+import * as dbUtil from '../db_util';
 import { LATEST_VERSION } from '../MongoBinary';
 import MongodbInstance from '../MongoInstance';
 
@@ -173,5 +174,13 @@ describe('MongodbInstance', () => {
     const pid: any = mongod.getPid();
     expect(pid).toBeGreaterThan(0);
     await mongod.kill();
+  });
+
+  it('"kill" should not call "killProcess" if no childProcesses are not running', async () => {
+    const mongod = new MongodbInstance({});
+    jest.spyOn(dbUtil, 'killProcess');
+    await mongod.kill();
+
+    expect(dbUtil.killProcess).not.toBeCalled();
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -209,4 +209,18 @@ describe('MongodbInstance', () => {
     expect(events.get(MongoInstanceEvents.instanceRawError)).toEqual('hello');
     expect(events.get(MongoInstanceEvents.instanceError)).toEqual('hello');
   });
+
+  it('"stderrHandler" should emit "instanceSTDERR"', () => {
+    const mongod = new MongodbInstance({});
+    const events: Map<MongoInstanceEvents | string, string> = new Map();
+    jest.spyOn(mongod, 'emit').mockImplementation((event: string, arg1: string) => {
+      events.set(event, arg1);
+      return true;
+    });
+
+    mongod.stderrHandler('hello');
+
+    expect(events.size).toEqual(1);
+    expect(events.get(MongoInstanceEvents.instanceSTDERR)).toEqual('hello');
+  });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance-test.ts
@@ -200,7 +200,7 @@ describe('MongodbInstance', () => {
     let events: Map<MongoInstanceEvents | string, string>;
     let spy: jest.SpyInstance;
     beforeAll(() => {
-      mongod = new MongodbInstance({});
+      mongod = new MongodbInstance({ instance: { port: 1001, dbPath: 'hello' } });
       events = new Map();
       spy = jest.spyOn(mongod, 'emit').mockImplementation((event: string, arg1: string) => {
         events.set(event, arg1);
@@ -237,6 +237,18 @@ describe('MongodbInstance', () => {
         expect(events.size).toEqual(2);
         expect(events.get(MongoInstanceEvents.instanceSTDOUT)).toEqual(line);
         expect(events.get(MongoInstanceEvents.instanceReady)).toEqual(undefined);
+      });
+
+      it('should emit "instanceError" when port is already in use', () => {
+        // actual line copied from mongod 4.0.14
+        const line =
+          '2020-09-30T19:00:43.555+0200 E STORAGE  [initandlisten] Failed to set up listener: SocketException: Address already in use';
+
+        mongod.stdoutHandler(line);
+
+        expect(events.size).toEqual(2);
+        expect(events.get(MongoInstanceEvents.instanceSTDOUT)).toEqual(line);
+        expect(events.get(MongoInstanceEvents.instanceError)).toEqual('Port 1001 already in use');
       });
     });
   });

--- a/packages/mongodb-memory-server-core/src/util/db_util.ts
+++ b/packages/mongodb-memory-server-core/src/util/db_util.ts
@@ -31,4 +31,16 @@ export function isNullOrUndefined(val: unknown): val is null | undefined {
   return val === null || val === undefined;
 }
 
+/**
+ * Assert an condition, if "false" throw error
+ * Note: it is not named "assert" to differentiate between node and jest types
+ * @param cond The Condition to throw
+ * @param error An Custom Error to throw
+ */
+export function assertion(cond: unknown, error?: Error): asserts cond {
+  if (!cond) {
+    throw error ?? new Error('Assert failed - no custom error [E019]');
+  }
+}
+
 export default generateDbName;


### PR DESCRIPTION
- rename interface "MongodOps" to "MongodOpts" to keep naming consistency
- remove static value "childProcessList" because it was never used
- move "dynamic" function "debug" into private class function
- shorten "constructor" to use less lines
- outsource "MongodOpts.instance" into own interface "MongoInstanceOpts"
- change root values of "MongodOpts" to be required
- remove unused return value inside "run"'s "launch" Promise
- add tsdoc to "kill"
- add tsdoc to "errorHandler"
- extend tsdoc for "closeHandler"
- remove value "opts"
- add value "instanceOpts"
- add value "binaryOpts"
- add value "spawnOpts"
- prepareCommandArgs: remove splitting "this.instanceOpts"
- prepareCommandArgs: convert values to booleans (to ensure no falsy values)
- improve tsdoc for "waitPrimaryReady"
- change "MongoInstance" to extend "EventEmitter"
- add various Events
- track event names with an enum
- handle not being PRIMARY anymore
- "_waitForPrimary" use new events instead of function
- remove function "waitPrimaryReady"
- remove value "waitForPrimaryResolveFns"
- replace instanceReady with Event "instanceReady"
- replace instanceFailed with Event "instanceError"
- remove case for "shutting down with code"
- update case for "address already in use"
- add listener to "run" on "instanceClosed"
- test the error value on reject
- change test name to be more readable and accurate
- feat(db_util): add function "assertion"
- add error if "post" is null/undefined in "prepareCommandArgs" (because that is the purpose if this package)
- add error if "dbPath" is null/undefined in "prepareCommandArgs" (because that is the purpose if this package)
- move "ip" inside an if
- enforce "stdio" to be always "pipe"
- try "SIGKILL" if process didnt exit within 10 seconds
- reject promise if process dosnt exit after sending "SIGKILL"
- rename parameter "process" to "childProcess" to not overwrite global "process"
- move function "kill_internal" from "MongoInstance" to "db_util"
- rename function "kill_internal" to "killProcess"
- log the array created in the function
- overwrite "emit", "on", "once" to only allow "MongoInstanceEvents" instead of "string | symbol"
- add "@fires" to all functions that emit an event
- test that "kill" dosnt call "killProcess" if no childProcesses are running
- test that "_launchMongod" throws if "childProcess.pid" is undefined
- test that "errorHandler" emits "instanceRawError" and "instanceError"
- test that "stderrHandler" emits "instanceSTDERR"
- test that "stdoutHandler" emits correct event on "waiting for connections"
- move all "event testing" tests into "test events"
- add "beforeAll" creating the spy & instance & events map
- add "beforeEach" resetting spy-calls & events map
- test that "stdoutHandler" emits correct event on "address already in use"
- test that "stdoutHandler" emits correct event on "CURL_OPENSSL_3"
- test that "stdoutHandler" emits correct event on "CURL_OPENSSL_4"
- test that "stdoutHandler" emits correct event on "transition primary complete"
- test that "stdoutHandler" emits correct event on "state change"
- add "TODO" for events in "stdoutHandler" in "MongoInstance" that arnt covered yet
- remove redundant "debug.enabled" check
- rename event "instanceState" to "instanceReplState"
- remove "| null" from "childProcess"
- remove "| null" from "killerProcess"
- change "childProcess" to be optional
- change "killerProcess" to be optional
- reset "childProcess" reference to "undefined" in "stop"
- reset "killerProcess" reference to "undefined" in "stop"
- test(replset-multi): remove variable "opts"
- add tsdoc to the variables in "Mongoinstance"

## Related Issues

- closes #365
- most likely fixes #166 

---

because this pr includes breaking changes, i thought to bring this together with other file-improvements