### PR TITLE
Fix/improveMongoMemoryServer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     sourceType: 'module',
     useJSXTextNode: true,
     project: [
+      path.resolve(__dirname, 'tsconfig.test.json'),
       path.resolve(__dirname, 'packages/mongodb-memory-server-core/tsconfig.json'),
     ],
   },

--- a/packages/mongodb-memory-server-core/jest.config.js
+++ b/packages/mongodb-memory-server-core/jest.config.js
@@ -14,4 +14,5 @@ module.exports = {
   roots: ['<rootDir>/src'],
   testPathIgnorePatterns: ['/node_modules/', '/lib/'],
   testMatch: ['**/__tests__/**/*-test.(ts|js)'],
+  testEnvironment: 'node',
 };

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -290,7 +290,7 @@ export class MongoMemoryReplSet extends EventEmitter {
     if (!this.servers.length) {
       throw new Error('One or more servers are required.');
     }
-    const uris = await Promise.all(this.servers.map((server) => server.getUri()));
+    const uris = this.servers.map((server) => server.getUri());
 
     let MongoClient: typeof mongodb.MongoClient;
     try {

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -211,7 +211,7 @@ export class MongoMemoryReplSet extends EventEmitter {
     } else {
       dbName = this.opts.replSet.dbName;
     }
-    const ports = await Promise.all(this.servers.map((s) => s.getPort()));
+    const ports = this.servers.map((s) => s.getPort());
     const hosts = ports.map((port) => `127.0.0.1:${port}`).join(',');
     return `mongodb://${hosts}/${dbName}?replicaSet=${this.opts.replSet.name}`;
   }

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -378,7 +378,7 @@ export class MongoMemoryReplSet extends EventEmitter {
       ...this.servers.map(
         (server) =>
           new Promise((res, rej) => {
-            const instanceInfo = server.getInstanceInfo();
+            const instanceInfo = server.instanceInfo;
             if (!instanceInfo) {
               return rej(new Error('_waitForPrimary - instanceInfo not present '));
             }

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -252,15 +252,15 @@ export class MongoMemoryReplSet extends EventEmitter {
     if (this._state === 'stopped') {
       return false;
     }
-    const servers = this.servers;
-    this.servers = [];
     process.removeListener('beforeExit', this.stop); // many accumulate inside tests
-    return Promise.all(servers.map((s) => s.stop()))
+    return Promise.all(this.servers.map((s) => s.stop()))
       .then(() => {
+        this.servers = [];
         this.emit((this._state = 'stopped'));
         return true;
       })
       .catch((err) => {
+        this.servers = [];
         log(err);
         this.emit((this._state = 'stopped'), err);
         return false;

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -354,7 +354,6 @@ export class MongoMemoryReplSet extends EventEmitter {
    */
   _initServer(instanceOpts: MongoMemoryInstancePropT): MongoMemoryServer {
     const serverOpts: MongoMemoryServerOptsT = {
-      autoStart: false,
       binary: this.opts.binary,
       instance: instanceOpts,
       spawn: this.opts.replSet.spawn,

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import * as mongodb from 'mongodb';
 import MongoMemoryServer from './MongoMemoryServer';
 import { MongoMemoryServerOptsT } from './MongoMemoryServer';
-import { generateDbName, getHost } from './util/db_util';
+import { assertion, generateDbName, getHost, isNullOrUndefined } from './util/db_util';
 import { MongoBinaryOpts } from './util/MongoBinary';
 import { MongoMemoryInstancePropT, MongoMemoryInstancePropBaseT, StorageEngineT } from './types';
 import debug from 'debug';
@@ -211,7 +211,11 @@ export class MongoMemoryReplSet extends EventEmitter {
     } else {
       dbName = this.opts.replSet.dbName;
     }
-    const ports = this.servers.map((s) => s.getPort());
+    const ports = this.servers.map((s) => {
+      const port = s.instanceInfo?.port;
+      assertion(!isNullOrUndefined(port), new Error('Instance Port is undefined!'));
+      return port;
+    });
     const hosts = ports.map((port) => `127.0.0.1:${port}`).join(',');
     return `mongodb://${hosts}/${dbName}?replicaSet=${this.opts.replSet.name}`;
   }

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -233,23 +233,23 @@ export class MongoMemoryServer {
   }
 
   /**
-   * Get a mongodb-URI for a different DataBase
-   * @param otherDbName Set this to "true" to generate a random DataBase name, otherwise a string to specify a DataBase name
+   * Generate the Connection string used by mongodb
+   * @param otherDbName Set an custom Database name, or set this to "true" to generate an different name
    */
-  async getUri(otherDbName: string | boolean = false): Promise<string> {
-    const { uri, port, ip }: MongoInstanceDataT = await this.ensureInstance();
+  getUri(otherDbName: string | boolean = false): string {
+    assertionInstanceInfoSync(this.instanceInfoSync);
 
     // IF true OR string
     if (otherDbName) {
       if (typeof otherDbName === 'string') {
         // generate uri with provided DB name on existed DB instance
-        return getUriBase(ip, port, otherDbName);
+        return getUriBase(this.instanceInfoSync.ip, this.instanceInfoSync.port, otherDbName);
       }
       // generate new random db name
-      return getUriBase(ip, port, generateDbName());
+      return getUriBase(this.instanceInfoSync.ip, this.instanceInfoSync.port, generateDbName());
     }
 
-    return uri;
+    return this.instanceInfoSync.uri;
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -47,8 +47,8 @@ export interface MongoInstanceDataT extends StartupInstanceData {
 }
 
 export class MongoMemoryServer {
-  runningInstance: Promise<MongoInstanceDataT> | null = null;
-  instanceInfoSync: MongoInstanceDataT | null = null;
+  runningInstance?: Promise<MongoInstanceDataT>;
+  instanceInfoSync?: MongoInstanceDataT;
   opts: MongoMemoryServerOptsT;
 
   /**
@@ -194,8 +194,8 @@ export class MongoMemoryServer {
     log(`Shutdown MongoDB server on port ${port} with pid ${instance.getPid() || ''}`);
     await instance.kill();
 
-    this.runningInstance = null;
-    this.instanceInfoSync = null;
+    this.runningInstance = undefined;
+    this.instanceInfoSync = undefined;
 
     if (tmpDir) {
       log(`Removing tmpDir ${tmpDir.name}`);

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -171,10 +171,16 @@ export class MongoMemoryServer {
       return true;
     }
 
+    // assert here, just to be sure
+    assertion(
+      !isNullOrUndefined(this.instanceInfo.instance),
+      new Error('"instanceInfo.instance" is undefined!')
+    );
+
     log(
-      `Shutdown MongoDB server on port ${this.instanceInfo.port} with pid ${
-        this.instanceInfo.instance.getPid() || ''
-      }`
+      `Shutdown MongoDB server on port ${
+        this.instanceInfo.port
+      } with pid ${this.instanceInfo.instance.getPid()}` // "undefined" would say more than ""
     );
     await this.instanceInfo.instance.kill();
 

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -12,13 +12,12 @@ const log = debug('MongoMS:MongoMemoryServer');
 tmp.setGracefulCleanup();
 
 /**
- * Starting Options
+ * MongoMemoryServer Stored Options
  */
 export interface MongoMemoryServerOptsT {
   instance?: MongoMemoryInstancePropT;
   binary?: MongoBinaryOpts;
   spawn?: SpawnOptions;
-  autoStart?: boolean;
 }
 
 /**
@@ -58,11 +57,6 @@ export class MongoMemoryServer {
    */
   constructor(opts?: MongoMemoryServerOptsT) {
     this.opts = { ...opts };
-
-    if (opts?.autoStart === true) {
-      log('Autostarting MongoDB instance...');
-      this.start();
-    }
   }
 
   /**
@@ -70,21 +64,14 @@ export class MongoMemoryServer {
    * @param opts Mongo-Memory-Sever Options
    */
   static async create(opts?: MongoMemoryServerOptsT): Promise<MongoMemoryServer> {
-    // create an instance WITHOUT autoStart so that the user can await it
-    const instance = new MongoMemoryServer({
-      ...opts,
-      autoStart: false,
-    });
-    if (opts?.autoStart) {
-      await instance.start();
-    }
+    const instance = new MongoMemoryServer({ ...opts });
+    await instance.start();
 
     return instance;
   }
 
   /**
    * Start the in-memory Instance
-   * (when options.autoStart is true, this already got called)
    */
   async start(): Promise<boolean> {
     log('Called MongoMemoryServer.start() method');

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -120,7 +120,7 @@ export class MongoMemoryServer {
       log(`starting with port ${data.port}, since ${instOpts.port} was locked:`, data.port);
     }
 
-    data.uri = await getUriBase(data.ip, data.port, data.dbName);
+    data.uri = getUriBase(data.ip, data.port, data.dbName);
     if (!data.dbPath) {
       data.tmpDir = tmp.dirSync({
         mode: 0o755,

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -67,7 +67,7 @@ export interface MongoMemoryServer extends EventEmitter {
 }
 
 export class MongoMemoryServer extends EventEmitter {
-  instanceInfo?: MongoInstanceDataT;
+  protected instanceInfo?: MongoInstanceDataT;
   opts: MongoMemoryServerOptsT;
   _state: MongoMemoryServerStateEnum = MongoMemoryServerStateEnum.new;
 

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -81,28 +81,28 @@ export class MongoMemoryServer {
       );
     }
 
-    this.runningInstance = this._startUpInstance()
+    const instance = await this._startUpInstance()
       .catch((err) => {
         if (err.message === 'Mongod shutting down' || err === 'Mongod shutting down') {
           log(`Mongodb did not start. Trying to start on another port one more time...`);
           if (this.opts.instance?.port) {
-            this.opts.instance.port = null;
+            this.opts.instance.port = undefined;
           }
           return this._startUpInstance();
         }
-        throw err;
+        throw err; // give error to next handler
       })
       .catch((err) => {
         if (!debug.enabled('MongoMS:MongoMemoryServer')) {
-          console.warn('Starting the instance failed, please enable debug for more infomation');
+          console.warn('Starting the instance failed, enable debug for more infomation');
         }
         throw err;
       });
 
-    return this.runningInstance.then((data) => {
-      this.instanceInfoSync = data;
-      return true;
-    });
+    this.runningInstance = new Promise((res) => res(instance));
+    this.instanceInfoSync = instance;
+
+    return true;
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -6,7 +6,6 @@ import MongoInstance from './util/MongoInstance';
 import { MongoBinaryOpts } from './util/MongoBinary';
 import { MongoMemoryInstancePropT, StorageEngineT } from './types';
 import debug from 'debug';
-import { deprecate } from 'util';
 
 const log = debug('MongoMS:MongoMemoryServer');
 
@@ -251,19 +250,6 @@ export class MongoMemoryServer {
     }
 
     return uri;
-  }
-
-  /**
-   * Get a mongodb-URI for a different DataBase
-   * @param otherDbName Set this to "true" to generate a random DataBase name, otherwise a string to specify a DataBase name
-   * @deprecated
-   */
-  async getConnectionString(otherDbName: string | boolean = false): Promise<string> {
-    return deprecate(
-      this.getUri,
-      '"MongoMemoryReplSet.getConnectionString" is deprecated, use ".getUri"',
-      'MDEP001'
-    ).call(this, otherDbName);
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, SpawnOptions } from 'child_process';
+import { SpawnOptions } from 'child_process';
 import * as tmp from 'tmp';
 import getPort from 'get-port';
 import { assertion, generateDbName, getUriBase, isNullOrUndefined } from './util/db_util';
@@ -41,7 +41,6 @@ export interface MongoInstanceDataT extends StartupInstanceData {
   dbPath: string; // re-declare, because in this interface it is *not* optional
   uri: string; // same as above
   instance: MongoInstance;
-  childProcess?: ChildProcess;
 }
 
 export class MongoMemoryServer {
@@ -152,7 +151,6 @@ export class MongoMemoryServer {
       dbPath: data.dbPath as string, // because otherwise the types would be incompatible
       uri: data.uri as string, // same as above
       instance: instance,
-      childProcess: instance.childProcess ?? undefined, // convert null | undefined to undefined
     };
   }
 

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -77,20 +77,12 @@ export class MongoMemoryServer {
       );
     }
 
-    this.instanceInfo = await this._startUpInstance()
-      .catch((err) => {
-        if (err.message === 'Mongod shutting down' || err === 'Mongod shutting down') {
-          log(`Mongodb did not start. Trying to start on another port one more time...`);
-          return this._startUpInstance();
-        }
-        throw err; // give error to next handler
-      })
-      .catch((err) => {
-        if (!debug.enabled('MongoMS:MongoMemoryServer')) {
-          console.warn('Starting the instance failed, enable debug for more infomation');
-        }
-        throw err;
-      });
+    this.instanceInfo = await this._startUpInstance().catch((err) => {
+      if (!debug.enabled('MongoMS:MongoMemoryServer')) {
+        console.warn('Starting the instance failed, enable debug for more infomation');
+      }
+      throw err;
+    });
 
     return true;
   }

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -298,15 +298,6 @@ export class MongoMemoryServer extends EventEmitter {
   }
 
   /**
-   * Get the DB-Path of the currently running Instance
-   */
-  getDbPath(): string {
-    assertionInstanceInfo(this._instanceInfo);
-    assertion(!isNullOrUndefined(this._instanceInfo.dbPath), new Error('"dbPath" is undefined'));
-    return this._instanceInfo.dbPath;
-  }
-
-  /**
    * Get the DB-Name of the currently running Instance
    */
   getDbName(): string {

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -67,7 +67,7 @@ export interface MongoMemoryServer extends EventEmitter {
 }
 
 export class MongoMemoryServer extends EventEmitter {
-  protected instanceInfo?: MongoInstanceDataT;
+  protected _instanceInfo?: MongoInstanceDataT;
   opts: MongoMemoryServerOptsT;
   _state: MongoMemoryServerStateEnum = MongoMemoryServerStateEnum.new;
 
@@ -108,7 +108,7 @@ export class MongoMemoryServer extends EventEmitter {
    */
   async start(): Promise<boolean> {
     log('Called MongoMemoryServer.start() method');
-    if (this.instanceInfo) {
+    if (this._instanceInfo) {
       throw new Error(
         'MongoDB instance already in status startup/running/error. Use debug for more info.'
       );
@@ -116,7 +116,7 @@ export class MongoMemoryServer extends EventEmitter {
 
     this.stateChange(MongoMemoryServerStateEnum.starting);
 
-    this.instanceInfo = await this._startUpInstance().catch((err) => {
+    this._instanceInfo = await this._startUpInstance().catch((err) => {
       if (!debug.enabled('MongoMS:MongoMemoryServer')) {
         console.warn('Starting the instance failed, enable debug for more infomation');
       }
@@ -190,31 +190,31 @@ export class MongoMemoryServer extends EventEmitter {
     log('Called MongoMemoryServer.stop() method');
 
     // just return "true" if the instance is already running / defined
-    if (isNullOrUndefined(this.instanceInfo)) {
+    if (isNullOrUndefined(this._instanceInfo)) {
       log('Instance is already stopped, returning true');
       return true;
     }
 
     // assert here, just to be sure
     assertion(
-      !isNullOrUndefined(this.instanceInfo.instance),
+      !isNullOrUndefined(this._instanceInfo.instance),
       new Error('"instanceInfo.instance" is undefined!')
     );
 
     log(
       `Shutdown MongoDB server on port ${
-        this.instanceInfo.port
-      } with pid ${this.instanceInfo.instance.getPid()}` // "undefined" would say more than ""
+        this._instanceInfo.port
+      } with pid ${this._instanceInfo.instance.getPid()}` // "undefined" would say more than ""
     );
-    await this.instanceInfo.instance.kill();
+    await this._instanceInfo.instance.kill();
 
-    const tmpDir = this.instanceInfo.tmpDir;
+    const tmpDir = this._instanceInfo.tmpDir;
     if (tmpDir) {
       log(`Removing tmpDir ${tmpDir.name}`);
       tmpDir.removeCallback();
     }
 
-    this.instanceInfo = undefined;
+    this._instanceInfo = undefined;
     this.stateChange(MongoMemoryServerStateEnum.stopped);
 
     return true;
@@ -224,7 +224,7 @@ export class MongoMemoryServer extends EventEmitter {
    * Get Information about the currently running instance, if it is not running it returns "undefined"
    */
   getInstanceInfo(): MongoInstanceDataT | undefined {
-    return this.instanceInfo;
+    return this._instanceInfo;
   }
 
   /**
@@ -233,8 +233,8 @@ export class MongoMemoryServer extends EventEmitter {
    */
   async ensureInstance(): Promise<MongoInstanceDataT> {
     log('Called MongoMemoryServer.ensureInstance() method');
-    if (this.instanceInfo) {
-      return this.instanceInfo;
+    if (this._instanceInfo) {
+      return this._instanceInfo;
     }
 
     switch (this._state) {
@@ -253,7 +253,7 @@ export class MongoMemoryServer extends EventEmitter {
                 )
               );
             }
-            res(this.instanceInfo);
+            res(this._instanceInfo);
           })
         );
       default:
@@ -265,11 +265,11 @@ export class MongoMemoryServer extends EventEmitter {
     log(' - `start()` command was succesfully resolved');
 
     // check again for 1. Typescript-type reasons and 2. if .start failed to throw an error
-    if (!this.instanceInfo) {
+    if (!this._instanceInfo) {
       throw new Error('Ensure-Instance failed to start an instance!');
     }
 
-    return this.instanceInfo;
+    return this._instanceInfo;
   }
 
   /**
@@ -277,9 +277,9 @@ export class MongoMemoryServer extends EventEmitter {
    * @param otherDbName Set an custom Database name, or set this to "true" to generate an different name
    */
   getUri(otherDbName?: string | boolean): string {
-    assertionInstanceInfo(this.instanceInfo);
+    assertionInstanceInfo(this._instanceInfo);
 
-    let dbName: string = this.instanceInfo.dbName;
+    let dbName: string = this._instanceInfo.dbName;
 
     // using "if" instead of nested "?:"
     if (!isNullOrUndefined(otherDbName)) {
@@ -287,34 +287,34 @@ export class MongoMemoryServer extends EventEmitter {
       dbName = typeof otherDbName === 'string' ? otherDbName : generateDbName();
     }
 
-    return getUriBase(this.instanceInfo.ip, this.instanceInfo.port, dbName);
+    return getUriBase(this._instanceInfo.ip, this._instanceInfo.port, dbName);
   }
 
   /**
    * Get the Port of the currently running Instance
    */
   getPort(): number {
-    assertionInstanceInfo(this.instanceInfo);
-    assertion(!isNullOrUndefined(this.instanceInfo.port), new Error('"port" is undefined'));
-    return this.instanceInfo.port;
+    assertionInstanceInfo(this._instanceInfo);
+    assertion(!isNullOrUndefined(this._instanceInfo.port), new Error('"port" is undefined'));
+    return this._instanceInfo.port;
   }
 
   /**
    * Get the DB-Path of the currently running Instance
    */
   getDbPath(): string {
-    assertionInstanceInfo(this.instanceInfo);
-    assertion(!isNullOrUndefined(this.instanceInfo.dbPath), new Error('"dbPath" is undefined'));
-    return this.instanceInfo.dbPath;
+    assertionInstanceInfo(this._instanceInfo);
+    assertion(!isNullOrUndefined(this._instanceInfo.dbPath), new Error('"dbPath" is undefined'));
+    return this._instanceInfo.dbPath;
   }
 
   /**
    * Get the DB-Name of the currently running Instance
    */
   getDbName(): string {
-    assertionInstanceInfo(this.instanceInfo);
-    assertion(!isNullOrUndefined(this.instanceInfo.dbName), new Error('"dbName" is undefined'));
-    return this.instanceInfo.dbName;
+    assertionInstanceInfo(this._instanceInfo);
+    assertion(!isNullOrUndefined(this._instanceInfo.dbName), new Error('"dbName" is undefined'));
+    return this._instanceInfo.dbName;
   }
 }
 

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -286,11 +286,11 @@ export class MongoMemoryServer {
 
   /**
    * Get the DB-Name of the currently running Instance
-   * Note: calls "ensureInstance"
    */
-  async getDbName(): Promise<string> {
-    const { dbName }: MongoInstanceDataT = await this.ensureInstance();
-    return dbName;
+  getDbName(): string {
+    assertionInstanceInfoSync(this.instanceInfoSync);
+    assertion(!isNullOrUndefined(this.instanceInfoSync.dbName), new Error('"dbName" is undefined'));
+    return this.instanceInfoSync.dbName;
   }
 }
 

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, SpawnOptions } from 'child_process';
 import * as tmp from 'tmp';
 import getPort from 'get-port';
-import { generateDbName, getUriBase, isNullOrUndefined } from './util/db_util';
+import { assertion, generateDbName, getUriBase, isNullOrUndefined } from './util/db_util';
 import MongoInstance from './util/MongoInstance';
 import { MongoBinaryOpts } from './util/MongoBinary';
 import { MongoMemoryInstancePropT, StorageEngineT } from './types';
@@ -268,11 +268,11 @@ export class MongoMemoryServer {
 
   /**
    * Get the Port of the currently running Instance
-   * Note: calls "ensureInstance"
    */
-  async getPort(): Promise<number> {
-    const { port }: MongoInstanceDataT = await this.ensureInstance();
-    return port;
+  getPort(): number {
+    assertionInstanceInfoSync(this.instanceInfoSync);
+    assertion(!isNullOrUndefined(this.instanceInfoSync.port), new Error('"port" is undefined'));
+    return this.instanceInfoSync.port;
   }
 
   /**
@@ -295,3 +295,12 @@ export class MongoMemoryServer {
 }
 
 export default MongoMemoryServer;
+
+/**
+ * This function is to de-duplicate code
+ * -> this couldnt be included in the class, because "asserts this.instanceInfoSync" is not allowed
+ * @param val this.instanceInfoSync
+ */
+function assertionInstanceInfoSync(val: unknown): asserts val is MongoInstanceDataT {
+  assertion(!isNullOrUndefined(val), new Error('"instanceInfoSync" is undefined'));
+}

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -218,20 +218,18 @@ export class MongoMemoryServer {
    * Generate the Connection string used by mongodb
    * @param otherDbName Set an custom Database name, or set this to "true" to generate an different name
    */
-  getUri(otherDbName: string | boolean = false): string {
+  getUri(otherDbName?: string | boolean): string {
     assertionInstanceInfoSync(this.instanceInfo);
 
-    // IF true OR string
-    if (otherDbName) {
-      if (typeof otherDbName === 'string') {
-        // generate uri with provided DB name on existed DB instance
-        return getUriBase(this.instanceInfo.ip, this.instanceInfo.port, otherDbName);
-      }
-      // generate new random db name
-      return getUriBase(this.instanceInfo.ip, this.instanceInfo.port, generateDbName());
+    let dbName: string = this.instanceInfo.dbName;
+
+    // using "if" instead of nested "?:"
+    if (!isNullOrUndefined(otherDbName)) {
+      // use "otherDbName" if string, otherwise generate an db-name
+      dbName = typeof otherDbName === 'string' ? otherDbName : generateDbName();
     }
 
-    return getUriBase(this.instanceInfo.ip, this.instanceInfo.port, this.instanceInfo.dbName);
+    return getUriBase(this.instanceInfo.ip, this.instanceInfo.port, dbName);
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -81,7 +81,6 @@ export class MongoMemoryServer {
       .catch((err) => {
         if (err.message === 'Mongod shutting down' || err === 'Mongod shutting down') {
           log(`Mongodb did not start. Trying to start on another port one more time...`);
-          this.opts.instance = { ...this.opts.instance, port: undefined }; // this will always set the "port" to undefined, even if "instance" is undefined
           return this._startUpInstance();
         }
         throw err; // give error to next handler

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -69,7 +69,7 @@ export interface MongoMemoryServer extends EventEmitter {
 export class MongoMemoryServer extends EventEmitter {
   protected _instanceInfo?: MongoInstanceDataT;
   opts: MongoMemoryServerOptsT;
-  _state: MongoMemoryServerStateEnum = MongoMemoryServerStateEnum.new;
+  protected _state: MongoMemoryServerStateEnum = MongoMemoryServerStateEnum.new;
 
   /**
    * Create an Mongo-Memory-Sever Instance

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -188,18 +188,23 @@ export class MongoMemoryServer {
       return true;
     }
 
-    const { instance, port, tmpDir }: MongoInstanceDataT = await this.ensureInstance();
+    assertionInstanceInfoSync(this.instanceInfoSync);
 
-    log(`Shutdown MongoDB server on port ${port} with pid ${instance.getPid() || ''}`);
-    await instance.kill();
+    log(
+      `Shutdown MongoDB server on port ${this.instanceInfoSync.port} with pid ${
+        this.instanceInfoSync.instance.getPid() || ''
+      }`
+    );
+    await this.instanceInfoSync.instance.kill();
 
-    this.runningInstance = undefined;
-    this.instanceInfoSync = undefined;
-
+    const tmpDir = this.instanceInfoSync.tmpDir;
     if (tmpDir) {
       log(`Removing tmpDir ${tmpDir.name}`);
       tmpDir.removeCallback();
     }
+
+    this.runningInstance = undefined;
+    this.instanceInfoSync = undefined;
 
     return true;
   }

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -219,7 +219,7 @@ export class MongoMemoryServer {
    * @param otherDbName Set an custom Database name, or set this to "true" to generate an different name
    */
   getUri(otherDbName?: string | boolean): string {
-    assertionInstanceInfoSync(this.instanceInfo);
+    assertionInstanceInfo(this.instanceInfo);
 
     let dbName: string = this.instanceInfo.dbName;
 
@@ -236,7 +236,7 @@ export class MongoMemoryServer {
    * Get the Port of the currently running Instance
    */
   getPort(): number {
-    assertionInstanceInfoSync(this.instanceInfo);
+    assertionInstanceInfo(this.instanceInfo);
     assertion(!isNullOrUndefined(this.instanceInfo.port), new Error('"port" is undefined'));
     return this.instanceInfo.port;
   }
@@ -245,7 +245,7 @@ export class MongoMemoryServer {
    * Get the DB-Path of the currently running Instance
    */
   getDbPath(): string {
-    assertionInstanceInfoSync(this.instanceInfo);
+    assertionInstanceInfo(this.instanceInfo);
     assertion(!isNullOrUndefined(this.instanceInfo.dbPath), new Error('"dbPath" is undefined'));
     return this.instanceInfo.dbPath;
   }
@@ -254,7 +254,7 @@ export class MongoMemoryServer {
    * Get the DB-Name of the currently running Instance
    */
   getDbName(): string {
-    assertionInstanceInfoSync(this.instanceInfo);
+    assertionInstanceInfo(this.instanceInfo);
     assertion(!isNullOrUndefined(this.instanceInfo.dbName), new Error('"dbName" is undefined'));
     return this.instanceInfo.dbName;
   }
@@ -264,9 +264,9 @@ export default MongoMemoryServer;
 
 /**
  * This function is to de-duplicate code
- * -> this couldnt be included in the class, because "asserts this.instanceInfoSync" is not allowed
- * @param val this.instanceInfoSync
+ * -> this couldnt be included in the class, because "asserts this.instanceInfo" is not allowed
+ * @param val this.instanceInfo
  */
-function assertionInstanceInfoSync(val: unknown): asserts val is MongoInstanceDataT {
+function assertionInstanceInfo(val: unknown): asserts val is MongoInstanceDataT {
   assertion(!isNullOrUndefined(val), new Error('"instanceInfo" is undefined'));
 }

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -277,11 +277,11 @@ export class MongoMemoryServer {
 
   /**
    * Get the DB-Path of the currently running Instance
-   * Note: calls "ensureInstance"
    */
-  async getDbPath(): Promise<string> {
-    const { dbPath }: MongoInstanceDataT = await this.ensureInstance();
-    return dbPath;
+  getDbPath(): string {
+    assertionInstanceInfoSync(this.instanceInfoSync);
+    assertion(!isNullOrUndefined(this.instanceInfoSync.dbPath), new Error('"dbPath" is undefined'));
+    return this.instanceInfoSync.dbPath;
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -205,10 +205,10 @@ export class MongoMemoryServer {
   }
 
   /**
-   * Get Information about the currently running instance, if it is not running it returns "false"
+   * Get Information about the currently running instance, if it is not running it returns "undefined"
    */
-  getInstanceInfo(): MongoInstanceDataT | false {
-    return this.instanceInfoSync ?? false;
+  getInstanceInfo(): MongoInstanceDataT | undefined {
+    return this.instanceInfoSync;
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -130,9 +130,8 @@ export class MongoMemoryServer {
       data.dbPath = data.tmpDir.name;
     }
 
-    log(`Starting MongoDB instance with following options: ${JSON.stringify(data)}`);
+    log(`Starting MongoDB instance with options: ${JSON.stringify(data)}`);
 
-    // Download if not exists mongo binaries in ~/.mongodb-prebuilt
     // After that startup MongoDB instance
     const instance = await MongoInstance.run({
       instance: {

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -84,9 +84,7 @@ export class MongoMemoryServer {
       .catch((err) => {
         if (err.message === 'Mongod shutting down' || err === 'Mongod shutting down') {
           log(`Mongodb did not start. Trying to start on another port one more time...`);
-          if (this.opts.instance?.port) {
-            this.opts.instance.port = undefined;
-          }
+          this.opts.instance = { ...this.opts.instance, port: undefined }; // this will always set the "port" to undefined, even if "instance" is undefined
           return this._startUpInstance();
         }
         throw err; // give error to next handler

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -28,7 +28,6 @@ export interface StartupInstanceData {
   dbPath?: string;
   dbName: string;
   ip: string;
-  uri?: string;
   storageEngine: StorageEngineT;
   replSet?: string;
   tmpDir?: tmp.DirResult;
@@ -39,7 +38,6 @@ export interface StartupInstanceData {
  */
 export interface MongoInstanceDataT extends StartupInstanceData {
   dbPath: string; // re-declare, because in this interface it is *not* optional
-  uri: string; // same as above
   instance: MongoInstance;
 }
 
@@ -119,7 +117,6 @@ export class MongoMemoryServer {
       log(`starting with port ${data.port}, since ${instOpts.port} was locked:`, data.port);
     }
 
-    data.uri = getUriBase(data.ip, data.port, data.dbName);
     if (!data.dbPath) {
       data.tmpDir = tmp.dirSync({
         mode: 0o755,
@@ -149,7 +146,6 @@ export class MongoMemoryServer {
     return {
       ...data,
       dbPath: data.dbPath as string, // because otherwise the types would be incompatible
-      uri: data.uri as string, // same as above
       instance: instance,
     };
   }
@@ -235,7 +231,7 @@ export class MongoMemoryServer {
       return getUriBase(this.instanceInfo.ip, this.instanceInfo.port, generateDbName());
     }
 
-    return this.instanceInfo.uri;
+    return getUriBase(this.instanceInfo.ip, this.instanceInfo.port, this.instanceInfo.dbName);
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -296,15 +296,6 @@ export class MongoMemoryServer extends EventEmitter {
 
     return getUriBase(this._instanceInfo.ip, this._instanceInfo.port, dbName);
   }
-
-  /**
-   * Get the DB-Name of the currently running Instance
-   */
-  getDbName(): string {
-    assertionInstanceInfo(this._instanceInfo);
-    assertion(!isNullOrUndefined(this._instanceInfo.dbName), new Error('"dbName" is undefined'));
-    return this._instanceInfo.dbName;
-  }
 }
 
 export default MongoMemoryServer;

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -223,7 +223,7 @@ export class MongoMemoryServer extends EventEmitter {
   /**
    * Get Information about the currently running instance, if it is not running it returns "undefined"
    */
-  getInstanceInfo(): MongoInstanceDataT | undefined {
+  get instanceInfo(): MongoInstanceDataT | undefined {
     return this._instanceInfo;
   }
 

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -228,6 +228,13 @@ export class MongoMemoryServer extends EventEmitter {
   }
 
   /**
+   * Get Current state of this class
+   */
+  get state(): MongoMemoryServerStateEnum {
+    return this._state;
+  }
+
+  /**
    * Ensure that the instance is running
    * -> throws if instance cannot be started
    */

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -298,15 +298,6 @@ export class MongoMemoryServer extends EventEmitter {
   }
 
   /**
-   * Get the Port of the currently running Instance
-   */
-  getPort(): number {
-    assertionInstanceInfo(this._instanceInfo);
-    assertion(!isNullOrUndefined(this._instanceInfo.port), new Error('"port" is undefined'));
-    return this._instanceInfo.port;
-  }
-
-  /**
    * Get the DB-Path of the currently running Instance
    */
   getDbPath(): string {

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -132,7 +132,7 @@ describe('MongoMemoryServer', () => {
   describe('getUri()', () => {
     it('"getUri" should return with "otherDb"', async () => {
       const mongoServer = await MongoMemoryServer.create({ autoStart: true });
-      const port: number = await mongoServer.getPort();
+      const port: number = mongoServer.getPort();
       expect(await mongoServer.getUri('customDB')).toBe(`mongodb://127.0.0.1:${port}/customDB?`);
 
       await mongoServer.stop();

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import * as tmp from 'tmp';
 import MongoMemoryServer, {
@@ -31,12 +32,12 @@ describe('MongoMemoryServer', () => {
       });
 
       const mongoServer2 = await MongoMemoryServer.create({
-        instance: { port: mongoServer1.getPort() },
+        instance: { port: mongoServer1.instanceInfo!.port },
       });
 
       expect(mongoServer1.instanceInfo).toBeDefined();
       expect(mongoServer2.instanceInfo).toBeDefined();
-      expect(mongoServer1.getPort()).not.toEqual(mongoServer2.getPort());
+      expect(mongoServer1.instanceInfo!.port).not.toEqual(mongoServer2.instanceInfo!.port);
 
       await mongoServer1.stop();
       await mongoServer2.stop();
@@ -189,17 +190,17 @@ describe('MongoMemoryServer', () => {
     });
 
     it('should return correct value with "otherDb" being a string', async () => {
-      const port: number = mongoServer.getPort();
+      const port: number = mongoServer.instanceInfo!.port;
       expect(mongoServer.getUri('customDB')).toEqual(`mongodb://127.0.0.1:${port}/customDB?`);
     });
 
     it('should return correct value with "otherDb" being a boolean', async () => {
-      const port: number = mongoServer.getPort();
+      const port: number = mongoServer.instanceInfo!.port;
       expect(mongoServer.getUri(true)).not.toEqual(`mongodb://127.0.0.1:${port}/hello?`);
     });
 
     it('should return correct value without "otherDb" being provided', async () => {
-      const port: number = mongoServer.getPort();
+      const port: number = mongoServer.instanceInfo!.port;
       const instanceInfo = mongoServer.instanceInfo;
       assertion(instanceInfo, new Error('"MongoServer.instanceInfo" should be defined!'));
       expect(mongoServer.getUri()).toEqual(`mongodb://127.0.0.1:${port}/${instanceInfo.dbName}?`);

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import * as tmp from 'tmp';
 import MongoMemoryServer, {
   MongoMemoryServerEventEnum,
@@ -83,6 +84,7 @@ describe('MongoMemoryServer', () => {
 
     it('should throw an error if "instanceInfo" is undefined but "_state" is "running"', async () => {
       const mongoServer = new MongoMemoryServer();
+      // @ts-expect-error
       mongoServer._state = MongoMemoryServerStateEnum.running;
 
       try {
@@ -111,6 +113,7 @@ describe('MongoMemoryServer', () => {
 
     it('should throw an error if state was "starting" and emitted an event but not "running"', async () => {
       const mongoServer = new MongoMemoryServer();
+      // @ts-expect-error
       mongoServer._state = MongoMemoryServerStateEnum.starting;
       const ensureInstancePromise = mongoServer.ensureInstance();
 

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -1,5 +1,6 @@
 import * as tmp from 'tmp';
 import MongoMemoryServer from '../MongoMemoryServer';
+import { assertion } from '../util/db_util';
 
 tmp.setGracefulCleanup();
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
@@ -133,12 +134,23 @@ describe('MongoMemoryServer', () => {
 
     it('should return correct value with "otherDb" being a string', async () => {
       const port: number = mongoServer.getPort();
-      expect(mongoServer.getUri('customDB')).toBe(`mongodb://127.0.0.1:${port}/customDB?`);
+      expect(mongoServer.getUri('customDB')).toEqual(`mongodb://127.0.0.1:${port}/customDB?`);
     });
 
     it('should return correct value with "otherDb" being a boolean', async () => {
       const port: number = mongoServer.getPort();
       expect(mongoServer.getUri(true)).not.toEqual(`mongodb://127.0.0.1:${port}/hello?`);
+    });
+
+    it('should return correct value without "otherDb" being provided', async () => {
+      const port: number = mongoServer.getPort();
+      assertion(
+        mongoServer.instanceInfo,
+        new Error('"MongoServer.instanceInfo" should be defined!')
+      );
+      expect(mongoServer.getUri()).toEqual(
+        `mongodb://127.0.0.1:${port}/${mongoServer.instanceInfo.dbName}?`
+      );
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -148,7 +148,7 @@ describe('MongoMemoryServer', () => {
 
     await mongoServer.start();
 
-    expect(await mongoServer.getDbPath()).toEqual(tmpDir.name);
+    expect(mongoServer.getDbPath()).toEqual(tmpDir.name);
 
     await mongoServer.stop();
     tmpDir.removeCallback();

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -197,13 +197,9 @@ describe('MongoMemoryServer', () => {
 
     it('should return correct value without "otherDb" being provided', async () => {
       const port: number = mongoServer.getPort();
-      assertion(
-        mongoServer.instanceInfo,
-        new Error('"MongoServer.instanceInfo" should be defined!')
-      );
-      expect(mongoServer.getUri()).toEqual(
-        `mongodb://127.0.0.1:${port}/${mongoServer.instanceInfo.dbName}?`
-      );
+      const instanceInfo = mongoServer.getInstanceInfo();
+      assertion(instanceInfo, new Error('"MongoServer.instanceInfo" should be defined!'));
+      expect(mongoServer.getUri()).toEqual(`mongodb://127.0.0.1:${port}/${instanceInfo.dbName}?`);
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -91,6 +91,20 @@ describe('MongoMemoryServer', () => {
         );
       }
     });
+
+    it('should throw an error if the given "_state" has no case', async () => {
+      const mongoServer = new MongoMemoryServer();
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      mongoServer._state = 'not Existing';
+
+      try {
+        await mongoServer.ensureInstance();
+        fail('Expected "ensureInstance" to throw');
+      } catch (err) {
+        expect(err.message).toEqual('"ensureInstance" does not have an case for "not Existing"');
+      }
+    });
   });
 
   describe('stop()', () => {

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -15,7 +15,7 @@ describe('MongoMemoryServer', () => {
     it('should resolve to true if an MongoInstanceData is resolved by _startUpInstance', async () => {
       MongoMemoryServer.prototype._startUpInstance = jest.fn(() => Promise.resolve({} as any));
 
-      const mongoServer = new MongoMemoryServer({ autoStart: false });
+      const mongoServer = new MongoMemoryServer();
 
       expect(MongoMemoryServer.prototype._startUpInstance).toHaveBeenCalledTimes(0);
 
@@ -31,7 +31,6 @@ describe('MongoMemoryServer', () => {
         .mockResolvedValueOnce({});
 
       const mongoServer = new MongoMemoryServer({
-        autoStart: false,
         instance: {
           port: 123,
         },
@@ -52,7 +51,6 @@ describe('MongoMemoryServer', () => {
       console.warn = jest.fn(); // mock it to prevent writing to console
 
       const mongoServer = new MongoMemoryServer({
-        autoStart: false,
         instance: {
           port: 123,
         },
@@ -70,7 +68,7 @@ describe('MongoMemoryServer', () => {
     it('should throw an error if not instance is running after calling start', async () => {
       MongoMemoryServer.prototype.start = jest.fn(() => Promise.resolve(true));
 
-      const mongoServer = new MongoMemoryServer({ autoStart: false });
+      const mongoServer = new MongoMemoryServer();
 
       await expect(mongoServer.ensureInstance()).rejects.toThrow(
         'Ensure-Instance failed to start an instance!'
@@ -82,9 +80,7 @@ describe('MongoMemoryServer', () => {
 
   describe('stop()', () => {
     it('should stop mongod and answer on isRunning() method', async () => {
-      const mongod = new MongoMemoryServer({
-        autoStart: false,
-      });
+      const mongod = new MongoMemoryServer({});
 
       expect(mongod.getInstanceInfo()).toBeFalsy();
       mongod.start();
@@ -100,8 +96,8 @@ describe('MongoMemoryServer', () => {
       expect(mongod.getInstanceInfo()).toBeFalsy();
     });
 
-    it('should return "true" early if not running', async () => {
-      const mongoServer = new MongoMemoryServer({ autoStart: false });
+    it('should throw an error if instance is undefined', async () => {
+      const mongoServer = new MongoMemoryServer();
       jest.spyOn(mongoServer, 'ensureInstance');
 
       expect(await mongoServer.stop()).toEqual(true);
@@ -116,14 +112,8 @@ describe('MongoMemoryServer', () => {
       MongoMemoryServer.prototype.start = jest.fn(() => Promise.resolve(true));
     });
 
-    it('should create an instance but not autostart', async () => {
+    it('should create an instance and call ".start"', async () => {
       await MongoMemoryServer.create();
-
-      expect(MongoMemoryServer.prototype.start).toHaveBeenCalledTimes(0);
-    });
-
-    it('should autostart and be awaitable', async () => {
-      await MongoMemoryServer.create({ autoStart: true });
 
       expect(MongoMemoryServer.prototype.start).toHaveBeenCalledTimes(1);
     });
@@ -131,7 +121,7 @@ describe('MongoMemoryServer', () => {
 
   describe('getUri()', () => {
     it('"getUri" should return with "otherDb"', async () => {
-      const mongoServer = await MongoMemoryServer.create({ autoStart: true });
+      const mongoServer = await MongoMemoryServer.create();
       const port: number = mongoServer.getPort();
       expect(mongoServer.getUri('customDB')).toBe(`mongodb://127.0.0.1:${port}/customDB?`);
 
@@ -142,7 +132,6 @@ describe('MongoMemoryServer', () => {
   it('"getDbPath" should return the dbPath', async () => {
     const tmpDir = tmp.dirSync({ prefix: 'mongo-mem-getDbPath-', unsafeCleanup: true });
     const mongoServer = new MongoMemoryServer({
-      autoStart: false,
       instance: { dbPath: tmpDir.name },
     });
 

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -97,6 +97,14 @@ describe('MongoMemoryServer', () => {
       await mongod.stop();
       expect(mongod.getInstanceInfo()).toBeFalsy();
     });
+
+    it('should return "true" early if not running', async () => {
+      const mongoServer = new MongoMemoryServer({ autoStart: false });
+      jest.spyOn(mongoServer, 'ensureInstance');
+
+      expect(await mongoServer.stop()).toEqual(true);
+      expect(mongoServer.ensureInstance).not.toHaveBeenCalled();
+    });
   });
 
   describe('create()', () => {

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -219,4 +219,12 @@ describe('MongoMemoryServer', () => {
     await mongoServer.stop();
     tmpDir.removeCallback();
   });
+
+  it('"state" should return correct state', () => {
+    const mongoServer = new MongoMemoryServer();
+    expect(mongoServer.state).toEqual(MongoMemoryServerStateEnum.new);
+    // @ts-expect-error
+    mongoServer.stateChange(MongoMemoryServerStateEnum.running);
+    expect(mongoServer.state).toEqual(MongoMemoryServerStateEnum.running);
+  });
 });

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -1,5 +1,8 @@
 import * as tmp from 'tmp';
-import MongoMemoryServer, { MongoMemoryServerStateEnum } from '../MongoMemoryServer';
+import MongoMemoryServer, {
+  MongoMemoryServerEventEnum,
+  MongoMemoryServerStateEnum,
+} from '../MongoMemoryServer';
 import { assertion } from '../util/db_util';
 
 tmp.setGracefulCleanup();
@@ -104,6 +107,18 @@ describe('MongoMemoryServer', () => {
       } catch (err) {
         expect(err.message).toEqual('"ensureInstance" does not have an case for "not Existing"');
       }
+    });
+
+    it('should throw an error if state was "starting" and emitted an event but not "running"', async () => {
+      const mongoServer = new MongoMemoryServer();
+      mongoServer._state = MongoMemoryServerStateEnum.starting;
+      const ensureInstancePromise = mongoServer.ensureInstance();
+
+      mongoServer.emit(MongoMemoryServerEventEnum.stateChange, MongoMemoryServerStateEnum.stopped);
+
+      expect(ensureInstancePromise).rejects.toThrow(
+        `"ensureInstance" waited for "running" but got an different state: "${MongoMemoryServerStateEnum.stopped}"`
+      );
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -133,7 +133,7 @@ describe('MongoMemoryServer', () => {
     it('"getUri" should return with "otherDb"', async () => {
       const mongoServer = await MongoMemoryServer.create({ autoStart: true });
       const port: number = mongoServer.getPort();
-      expect(await mongoServer.getUri('customDB')).toBe(`mongodb://127.0.0.1:${port}/customDB?`);
+      expect(mongoServer.getUri('customDB')).toBe(`mongodb://127.0.0.1:${port}/customDB?`);
 
       await mongoServer.stop();
     });

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -215,7 +215,7 @@ describe('MongoMemoryServer', () => {
 
     await mongoServer.start();
 
-    expect(mongoServer.getDbPath()).toEqual(tmpDir.name);
+    expect(mongoServer.instanceInfo!.dbPath).toEqual(tmpDir.name);
 
     await mongoServer.stop();
     tmpDir.removeCallback();

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -33,8 +33,8 @@ describe('MongoMemoryServer', () => {
         instance: { port: mongoServer1.getPort() },
       });
 
-      expect(mongoServer1.getInstanceInfo()).toBeDefined();
-      expect(mongoServer2.getInstanceInfo()).toBeDefined();
+      expect(mongoServer1.instanceInfo).toBeDefined();
+      expect(mongoServer2.instanceInfo).toBeDefined();
       expect(mongoServer1.getPort()).not.toEqual(mongoServer2.getPort());
 
       await mongoServer1.stop();
@@ -75,7 +75,7 @@ describe('MongoMemoryServer', () => {
       const mongoServer = await MongoMemoryServer.create();
       jest.spyOn(mongoServer, 'start'); // so it dosnt count the "start" call inside "create"
 
-      expect(await mongoServer.ensureInstance()).toEqual(mongoServer.getInstanceInfo());
+      expect(await mongoServer.ensureInstance()).toEqual(mongoServer.instanceInfo);
       expect(mongoServer.start).not.toHaveBeenCalled();
 
       await mongoServer.stop();
@@ -128,7 +128,7 @@ describe('MongoMemoryServer', () => {
       await mongoServer.ensureInstance();
 
       expect(mongoServer.start).toHaveBeenCalledTimes(1);
-      expect(mongoServer.getInstanceInfo()).toBeDefined();
+      expect(mongoServer.instanceInfo).toBeDefined();
 
       await mongoServer.stop();
     });
@@ -138,18 +138,18 @@ describe('MongoMemoryServer', () => {
     it('should start & stop mongod and check output of "getInstanceInfo"', async () => {
       const mongoServer = new MongoMemoryServer({});
 
-      expect(mongoServer.getInstanceInfo()).toBeFalsy();
+      expect(mongoServer.instanceInfo).toBeFalsy();
       mongoServer.start();
       // while mongod launching `getInstanceInfo` is false
-      expect(mongoServer.getInstanceInfo()).toBeFalsy(); // isnt this an race-condition?
+      expect(mongoServer.instanceInfo).toBeFalsy(); // isnt this an race-condition?
 
       // when instance launched then data became avaliable
       await mongoServer.ensureInstance();
-      expect(mongoServer.getInstanceInfo()).toBeDefined();
+      expect(mongoServer.instanceInfo).toBeDefined();
 
       // after stop, instance data should be empty
       await mongoServer.stop();
-      expect(mongoServer.getInstanceInfo()).toBeFalsy();
+      expect(mongoServer.instanceInfo).toBeFalsy();
     });
 
     it('should return "true" if no instance is running', async () => {
@@ -197,7 +197,7 @@ describe('MongoMemoryServer', () => {
 
     it('should return correct value without "otherDb" being provided', async () => {
       const port: number = mongoServer.getPort();
-      const instanceInfo = mongoServer.getInstanceInfo();
+      const instanceInfo = mongoServer.instanceInfo;
       assertion(instanceInfo, new Error('"MongoServer.instanceInfo" should be defined!'));
       expect(mongoServer.getUri()).toEqual(`mongodb://127.0.0.1:${port}/${instanceInfo.dbName}?`);
     });

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -1,5 +1,7 @@
+import * as tmp from 'tmp';
 import MongoMemoryServerType from '../MongoMemoryServer';
 
+tmp.setGracefulCleanup();
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 
 describe('MongoMemoryServer', () => {
@@ -135,5 +137,20 @@ describe('MongoMemoryServer', () => {
 
       await mongoServer.stop();
     });
+  });
+
+  it('"getDbPath" should return the dbPath', async () => {
+    const tmpDir = tmp.dirSync({ prefix: 'mongo-mem-getDbPath-', unsafeCleanup: true });
+    const mongoServer = new MongoMemoryServer({
+      autoStart: false,
+      instance: { dbPath: tmpDir.name },
+    });
+
+    await mongoServer.start();
+
+    expect(await mongoServer.getDbPath()).toEqual(tmpDir.name);
+
+    await mongoServer.stop();
+    tmpDir.removeCallback();
   });
 });

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -112,11 +112,9 @@ describe('MongoMemoryServer', () => {
         .spyOn(MongoMemoryServer.prototype, 'start')
         .mockImplementationOnce(() => Promise.resolve(true));
 
-      const mongoServer = await MongoMemoryServer.create();
+      await MongoMemoryServer.create();
 
       expect(MongoMemoryServer.prototype.start).toHaveBeenCalledTimes(1);
-
-      await mongoServer.stop();
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -57,7 +57,7 @@ describe('MongoMemoryServer', () => {
   });
 
   describe('ensureInstance()', () => {
-    it('should throw an error if not instance is running after calling start', async () => {
+    it('should throw an error if no "instanceInfo" is defined after calling start', async () => {
       const mongoServer = new MongoMemoryServer();
       jest.spyOn(mongoServer, 'start').mockImplementationOnce(() => Promise.resolve(true));
 
@@ -80,7 +80,7 @@ describe('MongoMemoryServer', () => {
   });
 
   describe('stop()', () => {
-    it('should stop mongod and answer on isRunning() method', async () => {
+    it('should start & stop mongod and check output of "getInstanceInfo"', async () => {
       const mongoServer = new MongoMemoryServer({});
 
       expect(mongoServer.getInstanceInfo()).toBeFalsy();
@@ -97,7 +97,7 @@ describe('MongoMemoryServer', () => {
       expect(mongoServer.getInstanceInfo()).toBeFalsy();
     });
 
-    it('should throw an error if instance is undefined', async () => {
+    it('should return "true" if no instance is running', async () => {
       const mongoServer = new MongoMemoryServer();
       jest.spyOn(mongoServer, 'ensureInstance');
 

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -1,5 +1,5 @@
 import * as tmp from 'tmp';
-import MongoMemoryServer from '../MongoMemoryServer';
+import MongoMemoryServer, { MongoMemoryServerStateEnum } from '../MongoMemoryServer';
 import { assertion } from '../util/db_util';
 
 tmp.setGracefulCleanup();
@@ -76,6 +76,20 @@ describe('MongoMemoryServer', () => {
       expect(mongoServer.start).not.toHaveBeenCalled();
 
       await mongoServer.stop();
+    });
+
+    it('should throw an error if "instanceInfo" is undefined but "_state" is "running"', async () => {
+      const mongoServer = new MongoMemoryServer();
+      mongoServer._state = MongoMemoryServerStateEnum.running;
+
+      try {
+        await mongoServer.ensureInstance();
+        fail('Expected "ensureInstance" to throw');
+      } catch (err) {
+        expect(err.message).toEqual(
+          'MongoMemoryServer "_state" is "running" but "instanceInfo" is undefined!'
+        );
+      }
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer-test.ts
@@ -120,6 +120,18 @@ describe('MongoMemoryServer', () => {
         `"ensureInstance" waited for "running" but got an different state: "${MongoMemoryServerStateEnum.stopped}"`
       );
     });
+
+    it('should also call "start" and actually start an server', async () => {
+      const mongoServer = new MongoMemoryServer();
+      jest.spyOn(mongoServer, 'start');
+
+      await mongoServer.ensureInstance();
+
+      expect(mongoServer.start).toHaveBeenCalledTimes(1);
+      expect(mongoServer.getInstanceInfo()).toBeDefined();
+
+      await mongoServer.stop();
+    });
   });
 
   describe('stop()', () => {

--- a/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
@@ -3,49 +3,49 @@ import MongoMemoryServer from '../MongoMemoryServer';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 
-let con1: MongoClient;
-let con2: MongoClient;
-let db1: Db;
-let db2: Db;
-let mongoServer1: MongoMemoryServer;
-let mongoServer2: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer1 = await MongoMemoryServer.create();
-  const mongoUri = mongoServer1.getUri();
-  con1 = await MongoClient.connect(mongoUri, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-  });
-
-  db1 = con1.db(mongoServer1.getDbName());
-
-  mongoServer2 = await MongoMemoryServer.create();
-  const mongoUri2 = mongoServer2.getUri();
-  con2 = await MongoClient.connect(mongoUri2, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-  });
-
-  db2 = con2.db(mongoServer1.getDbName());
-});
-
-afterAll(async () => {
-  if (con1) {
-    await con1.close();
-  }
-  if (con2) {
-    await con2.close();
-  }
-  if (mongoServer1) {
-    await mongoServer1.stop();
-  }
-  if (mongoServer2) {
-    await mongoServer2.stop();
-  }
-});
-
 describe('Multiple mongoServers', () => {
+  let con1: MongoClient;
+  let con2: MongoClient;
+  let db1: Db;
+  let db2: Db;
+  let mongoServer1: MongoMemoryServer;
+  let mongoServer2: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer1 = await MongoMemoryServer.create();
+    const mongoUri = mongoServer1.getUri();
+    con1 = await MongoClient.connect(mongoUri, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+
+    db1 = con1.db(mongoServer1.getDbName());
+
+    mongoServer2 = await MongoMemoryServer.create();
+    const mongoUri2 = mongoServer2.getUri();
+    con2 = await MongoClient.connect(mongoUri2, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+
+    db2 = con2.db(mongoServer1.getDbName());
+  });
+
+  afterAll(async () => {
+    if (con1) {
+      await con1.close();
+    }
+    if (con2) {
+      await con2.close();
+    }
+    if (mongoServer1) {
+      await mongoServer1.stop();
+    }
+    if (mongoServer2) {
+      await mongoServer2.stop();
+    }
+  });
+
   it('should start several servers', async () => {
     expect(db1).toBeDefined();
     const col1 = db1.collection('test');

--- a/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
@@ -12,7 +12,7 @@ let mongoServer2: MongoMemoryServer;
 
 beforeAll(async () => {
   mongoServer1 = await MongoMemoryServer.create({ autoStart: true });
-  const mongoUri = await mongoServer1.getUri();
+  const mongoUri = mongoServer1.getUri();
   con1 = await MongoClient.connect(mongoUri, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
@@ -21,7 +21,7 @@ beforeAll(async () => {
   db1 = con1.db(mongoServer1.getDbName());
 
   mongoServer2 = await MongoMemoryServer.create({ autoStart: true });
-  const mongoUri2 = await mongoServer2.getUri();
+  const mongoUri2 = mongoServer2.getUri();
   con2 = await MongoClient.connect(mongoUri2, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
@@ -60,14 +60,14 @@ describe('Multiple mongoServers', () => {
     expect(await col2.countDocuments({})).toBe(2);
   });
 
-  it('should have different uri', async () => {
-    const uri1 = await mongoServer1.getUri();
-    const uri2 = await mongoServer2.getUri();
+  it('should have different uri', () => {
+    const uri1 = mongoServer1.getUri();
+    const uri2 = mongoServer2.getUri();
     expect(uri1).not.toEqual(uri2);
   });
 
-  it('v6.0.0 adds "?" to the connection string (uri)', async () => {
-    const uri1 = await mongoServer1.getUri();
+  it('v6.0.0 adds "?" to the connection string (uri)', () => {
+    const uri1 = mongoServer1.getUri();
     expect(uri1.includes('?')).toBeTruthy();
   });
 });

--- a/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
@@ -11,7 +11,7 @@ let mongoServer1: MongoMemoryServer;
 let mongoServer2: MongoMemoryServer;
 
 beforeAll(async () => {
-  mongoServer1 = await MongoMemoryServer.create({ autoStart: true });
+  mongoServer1 = await MongoMemoryServer.create();
   const mongoUri = mongoServer1.getUri();
   con1 = await MongoClient.connect(mongoUri, {
     useNewUrlParser: true,
@@ -20,7 +20,7 @@ beforeAll(async () => {
 
   db1 = con1.db(mongoServer1.getDbName());
 
-  mongoServer2 = await MongoMemoryServer.create({ autoStart: true });
+  mongoServer2 = await MongoMemoryServer.create();
   const mongoUri2 = mongoServer2.getUri();
   con2 = await MongoClient.connect(mongoUri2, {
     useNewUrlParser: true,

--- a/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
@@ -32,10 +32,10 @@ beforeAll(async () => {
 
 afterAll(async () => {
   if (con1) {
-    con1.close();
+    await con1.close();
   }
   if (con2) {
-    con2.close();
+    await con2.close();
   }
   if (mongoServer1) {
     await mongoServer1.stop();

--- a/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { MongoClient } from 'mongodb';
 import MongoMemoryServer from '../MongoMemoryServer';
 
@@ -39,8 +40,8 @@ describe('Multiple mongoServers', () => {
   });
 
   it('should start several servers', async () => {
-    const db1 = con1.db(mongoServer1.getDbName());
-    const db2 = con2.db(mongoServer1.getDbName());
+    const db1 = con1.db(mongoServer1.instanceInfo!.dbName);
+    const db2 = con2.db(mongoServer1.instanceInfo!.dbName);
 
     expect(db1).toBeDefined();
     const col1 = db1.collection('test');

--- a/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
@@ -1,4 +1,4 @@
-import { Db, MongoClient } from 'mongodb';
+import { MongoClient } from 'mongodb';
 import MongoMemoryServer from '../MongoMemoryServer';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
@@ -6,29 +6,21 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 describe('Multiple mongoServers', () => {
   let con1: MongoClient;
   let con2: MongoClient;
-  let db1: Db;
-  let db2: Db;
   let mongoServer1: MongoMemoryServer;
   let mongoServer2: MongoMemoryServer;
 
   beforeAll(async () => {
     mongoServer1 = await MongoMemoryServer.create();
-    const mongoUri = mongoServer1.getUri();
-    con1 = await MongoClient.connect(mongoUri, {
+    con1 = await MongoClient.connect(mongoServer1.getUri(), {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });
-
-    db1 = con1.db(mongoServer1.getDbName());
 
     mongoServer2 = await MongoMemoryServer.create();
-    const mongoUri2 = mongoServer2.getUri();
-    con2 = await MongoClient.connect(mongoUri2, {
+    con2 = await MongoClient.connect(mongoServer2.getUri(), {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });
-
-    db2 = con2.db(mongoServer1.getDbName());
   });
 
   afterAll(async () => {
@@ -47,6 +39,9 @@ describe('Multiple mongoServers', () => {
   });
 
   it('should start several servers', async () => {
+    const db1 = con1.db(mongoServer1.getDbName());
+    const db2 = con2.db(mongoServer1.getDbName());
+
     expect(db1).toBeDefined();
     const col1 = db1.collection('test');
     const result1 = await col1.insertMany([{ a: 1 }, { b: 1 }]);

--- a/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
@@ -18,7 +18,7 @@ beforeAll(async () => {
     useUnifiedTopology: true,
   });
 
-  db1 = con1.db(await mongoServer1.getDbName());
+  db1 = con1.db(mongoServer1.getDbName());
 
   mongoServer2 = new MongoMemoryServer();
   const mongoUri2 = await mongoServer2.getUri();
@@ -27,7 +27,7 @@ beforeAll(async () => {
     useUnifiedTopology: true,
   });
 
-  db2 = con2.db(await mongoServer1.getDbName());
+  db2 = con2.db(mongoServer1.getDbName());
 });
 
 afterAll(async () => {

--- a/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/multipleDB-test.ts
@@ -11,7 +11,7 @@ let mongoServer1: MongoMemoryServer;
 let mongoServer2: MongoMemoryServer;
 
 beforeAll(async () => {
-  mongoServer1 = new MongoMemoryServer();
+  mongoServer1 = await MongoMemoryServer.create({ autoStart: true });
   const mongoUri = await mongoServer1.getUri();
   con1 = await MongoClient.connect(mongoUri, {
     useNewUrlParser: true,
@@ -20,7 +20,7 @@ beforeAll(async () => {
 
   db1 = con1.db(mongoServer1.getDbName());
 
-  mongoServer2 = new MongoMemoryServer();
+  mongoServer2 = await MongoMemoryServer.create({ autoStart: true });
   const mongoUri2 = await mongoServer2.getUri();
   con2 = await MongoClient.connect(mongoUri2, {
     useNewUrlParser: true,

--- a/packages/mongodb-memory-server-core/src/__tests__/replset-multi-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-multi-test.ts
@@ -19,7 +19,7 @@ describe('multi-member replica set', () => {
     await replSet.waitUntilRunning();
     const uri = await replSet.getUri();
 
-    const conn = await MongoClient.connect(uri, {
+    const con = await MongoClient.connect(uri, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });
@@ -27,12 +27,13 @@ describe('multi-member replica set', () => {
     // await while all SECONDARIES will be ready
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    const db = await conn.db(await replSet.getDbName());
+    const db = await con.db(await replSet.getDbName());
     const admin = db.admin();
     const status = await admin.replSetGetStatus();
     expect(status.members.filter((m: any) => m.stateStr === 'PRIMARY')).toHaveLength(1);
     expect(status.members.filter((m: any) => m.stateStr === 'SECONDARY')).toHaveLength(2);
 
+    await con.close();
     await replSet.stop();
   });
 });

--- a/packages/mongodb-memory-server-core/src/__tests__/replset-single-restart-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-single-restart-test.ts
@@ -33,7 +33,7 @@ describe('single-member replica set', () => {
 
     // Write real port to config (because 27017 may be busy, we need to get real port)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    opts.instanceOpts![0].port = await replSetBefore.servers[0].getPort();
+    opts.instanceOpts![0].port = replSetBefore.servers[0].getPort();
 
     await replSetBefore.stop();
 

--- a/packages/mongodb-memory-server-core/src/__tests__/replset-single-restart-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-single-restart-test.ts
@@ -33,7 +33,7 @@ describe('single-member replica set', () => {
 
     // Write real port to config (because 27017 may be busy, we need to get real port)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    opts.instanceOpts![0].port = replSetBefore.servers[0].getPort();
+    opts.instanceOpts![0].port = replSetBefore.servers[0].instanceInfo!.port;
 
     await replSetBefore.stop();
 

--- a/packages/mongodb-memory-server-core/src/__tests__/replset-single-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-single-test.ts
@@ -43,16 +43,17 @@ describe('single server replset', () => {
     await replSet.stop();
   });
 
-  it('should be possible to connect replicaset after waitUntilRunning resolveds', async () => {
+  it('should be possible to connect replicaset after waitUntilRunning resolves', async () => {
     const replSet = new MongoMemoryReplSet();
     await replSet.waitUntilRunning();
     const uri = await replSet.getUri();
 
-    await MongoClient.connect(`${uri}?replicaSet=testset`, {
+    const con = await MongoClient.connect(`${uri}?replicaSet=testset`, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });
 
+    await con.close();
     await replSet.stop();
   });
 });

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { MongoClient } from 'mongodb';
 import MongoMemoryServer from '../MongoMemoryServer';
 
@@ -25,7 +26,7 @@ describe('Single mongoServer', () => {
   });
 
   it('should start mongo server', async () => {
-    const db = con.db(mongoServer.getDbName());
+    const db = con.db(mongoServer.instanceInfo!.dbName);
 
     expect(db).toBeDefined();
     const col = db.collection('test');

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -2,31 +2,32 @@ import { Db, MongoClient } from 'mongodb';
 import MongoMemoryServer from '../MongoMemoryServer';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
-let con: MongoClient;
-let db: Db;
-let mongoServer: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
-  const mongoUri = mongoServer.getUri();
-  con = await MongoClient.connect(mongoUri, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-  });
-
-  db = con.db(mongoServer.getDbName());
-});
-
-afterAll(async () => {
-  if (con) {
-    con.close();
-  }
-  if (mongoServer) {
-    await mongoServer.stop();
-  }
-});
 
 describe('Single mongoServer', () => {
+  let con: MongoClient;
+  let db: Db;
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    con = await MongoClient.connect(mongoUri, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+
+    db = con.db(mongoServer.getDbName());
+  });
+
+  afterAll(async () => {
+    if (con) {
+      con.close();
+    }
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+  });
+
   it('should start mongo server', async () => {
     expect(db).toBeDefined();
     const col = db.collection('test');

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -7,7 +7,7 @@ let db: Db;
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
-  mongoServer = new MongoMemoryServer();
+  mongoServer = await MongoMemoryServer.create({ autoStart: true });
   const mongoUri = await mongoServer.getUri();
   con = await MongoClient.connect(mongoUri, {
     useNewUrlParser: true,

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -37,6 +37,8 @@ describe('Single mongoServer', () => {
   it('should throw error on start if there is already a running instance', async () => {
     const mongoServer2 = new MongoMemoryServer();
     // this case can normally happen if "start" is called again
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
     mongoServer2.instanceInfo = {} as any; // artificially set this to {} to not be undefined anymore
     await expect(mongoServer2.start()).rejects.toThrow(
       'MongoDB instance already in status startup/running/error. Use debug for more info.'

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -8,7 +8,7 @@ let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
   mongoServer = await MongoMemoryServer.create({ autoStart: true });
-  const mongoUri = await mongoServer.getUri();
+  const mongoUri = mongoServer.getUri();
   con = await MongoClient.connect(mongoUri, {
     useNewUrlParser: true,
     useUnifiedTopology: true,

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -7,7 +7,7 @@ let db: Db;
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create({ autoStart: true });
+  mongoServer = await MongoMemoryServer.create();
   const mongoUri = mongoServer.getUri();
   con = await MongoClient.connect(mongoUri, {
     useNewUrlParser: true,
@@ -36,7 +36,7 @@ describe('Single mongoServer', () => {
   });
 
   it('should throw error on start if there is already a running instance', async () => {
-    const mongoServer2 = new MongoMemoryServer({ autoStart: false });
+    const mongoServer2 = new MongoMemoryServer();
     mongoServer2.runningInstance = Promise.resolve({}) as Promise<MongoInstanceDataT>;
     await expect(mongoServer2.start()).rejects.toThrow(
       'MongoDB instance already in status startup/running/error. Use debug for more info.'

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -39,7 +39,7 @@ describe('Single mongoServer', () => {
     // this case can normally happen if "start" is called again
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
-    mongoServer2.instanceInfo = {} as any; // artificially set this to {} to not be undefined anymore
+    mongoServer2._instanceInfo = {} as any; // artificially set this to {} to not be undefined anymore
     await expect(mongoServer2.start()).rejects.toThrow(
       'MongoDB instance already in status startup/running/error. Use debug for more info.'
     );

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -1,5 +1,5 @@
 import { Db, MongoClient } from 'mongodb';
-import MongoMemoryServer, { MongoInstanceDataT } from '../MongoMemoryServer';
+import MongoMemoryServer from '../MongoMemoryServer';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 let con: MongoClient;
@@ -37,7 +37,8 @@ describe('Single mongoServer', () => {
 
   it('should throw error on start if there is already a running instance', async () => {
     const mongoServer2 = new MongoMemoryServer();
-    mongoServer2.runningInstance = Promise.resolve({}) as Promise<MongoInstanceDataT>;
+    // this case can normally happen if "start" is called again
+    mongoServer2.instanceInfo = {} as any; // artificially set this to {} to not be undefined anymore
     await expect(mongoServer2.start()).rejects.toThrow(
       'MongoDB instance already in status startup/running/error. Use debug for more info.'
     );

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -1,27 +1,23 @@
-import { Db, MongoClient } from 'mongodb';
+import { MongoClient } from 'mongodb';
 import MongoMemoryServer from '../MongoMemoryServer';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 
 describe('Single mongoServer', () => {
   let con: MongoClient;
-  let db: Db;
   let mongoServer: MongoMemoryServer;
 
   beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
-    const mongoUri = mongoServer.getUri();
-    con = await MongoClient.connect(mongoUri, {
+    con = await MongoClient.connect(mongoServer.getUri(), {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });
-
-    db = con.db(mongoServer.getDbName());
   });
 
   afterAll(async () => {
     if (con) {
-      con.close();
+      await con.close();
     }
     if (mongoServer) {
       await mongoServer.stop();
@@ -29,6 +25,8 @@ describe('Single mongoServer', () => {
   });
 
   it('should start mongo server', async () => {
+    const db = con.db(mongoServer.getDbName());
+
     expect(db).toBeDefined();
     const col = db.collection('test');
     const result = await col.insertMany([{ a: 1 }, { b: 1 }]);

--- a/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/singleDB-test.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
     useUnifiedTopology: true,
   });
 
-  db = con.db(await mongoServer.getDbName());
+  db = con.db(mongoServer.getDbName());
 });
 
 afterAll(async () => {

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -64,9 +64,11 @@ export interface MongoInstance extends EventEmitter {
  * This Class starts & stops the "mongod" process directly and handles stdout, sterr and close events
  */
 export class MongoInstance extends EventEmitter {
-  instanceOpts: MongoInstanceOpts;
-  binaryOpts: MongoBinaryOpts;
-  spawnOpts: SpawnOptions;
+  // Mark these values as "readonly" & "Readonly" because modifying them after starting will have no effect
+  // readonly is required otherwise the property can still be changed on the root level
+  readonly instanceOpts: Readonly<MongoInstanceOpts>;
+  readonly binaryOpts: Readonly<MongoBinaryOpts>;
+  readonly spawnOpts: Readonly<SpawnOptions>;
 
   /**
    * The "mongod" Process reference

--- a/packages/mongodb-memory-server-core/src/util/db_util.ts
+++ b/packages/mongodb-memory-server-core/src/util/db_util.ts
@@ -59,7 +59,7 @@ export async function killProcess(childprocess: ChildProcess, name: string): Pro
   await new Promise((resolve, reject) => {
     let timeout = setTimeout(() => {
       log('killProcess timeout triggered, trying SIGKILL');
-      if (!debug.enabled('MongoMS:MongoInstance')) {
+      if (!debug.enabled('MongoMS:db_util')) {
         console.warn(
           'An Process didnt exit with signal "SIGINT" within 10 seconds, using "SIGKILL"!\n' +
             'Enable debug logs for more information'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,5 @@
   },
   "files": [],
   "include": [],
-  "references": [{ "path": "./tsconfig.build.json" }]
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./packages/mongodb-memory-server-core/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+  },
+  "include": ["packages/**/*"]
+}


### PR DESCRIPTION
- remove double check
- remove "null" use "undefined"
- convert one if to optional-chaining
- remove unnecessary "else" path
- test that "stop" returns "true" if not running
- test that "getDbPath" returns the dbPath
- add "assertion"
- change "getPort" to be sync
- change "getDbPath" to be sync
- change "getDbName" to be sync
- (singleDB) remove call to "getConnectionString" and use ".create"
- (multipleDB) remove call to "getConnectionString" and use ".create"
- remove deprecated function "getConnectionString"
- change "getUri" to be sync
- change "getInstanceInfo" to return undefined
- remove call to "ensureInstance" inside "stop"
- remove option "autoStart"
- change that "create" now always calls ".start"
- remove test "should create an instance but not autostart"
- refactor "start" to be more readable
- merge "runningInstance" and "instanceInfoSync" into "instanceInfo"
- test that "ensureInstance" returns early if already running
- move test "getUri" with "otherDb" into MongoMemoryServer-test
- test that "getUri" returns generated otherDb
- (MongoMemoryServer-test) refactor file to be more readable
- add assertion for sanity to check if "instanceInfo.instance" is defined
- always reset "port" to "undefined" if instance failed and not just when "defined"
- killProcess: fix "SIGINT"-"SIGKILL" warn condition
- remove "await" from "getUriBase" call
- remove comment & change log
- remove "MongoInstanceDataT.childProcess"
- remove "StartupInstanceData.uri"
- shorten "getUri"
- rename function "assertionInstanceInfoSync" to "assertionInstanceInfo"
- change "instanceOpts" to be readonly and Readonly
- change "binaryOpts" to be readonly and Readonly
- change "spawnOpts" to be readonly and Readonly
- remove resetting "port" inside "start"
- test that "getUri" returns correct value if no parameter is provided
- start: remove first ".catch"
- test(MongoMemoryServer): change test names to represent the tests
- test(multipleDB): await connection.close
- test(multipleDB): move "beforeAll" and "afterAll" hooks inside describe
- test(multipleDB): move "db1" and "db2" inside only using test
- test(singleDB): move "beforeAll" and "afterAll" hooks inside describe
- test(singleDB): await connection.close & move "db" inside test
- stop: reset "servers" after stopping them
- remove "stop" call where "start" is mocked
- change "MongoMemoryServer" to extend "EventEmitter"
- add enum "MongoMemoryServerStateEnum"
- add enum "MongoMemoryServerEventEnum"
- add function "stateChange"
- ensureInstance: fix starting calling "start" even when "start" was already called
- test that "ensureInstance" throws if "instanceInfo" is "undefined" but "_state" is "running"
- test that "ensureInstance" throws if "_state" has no case
- test that "ensureInstance" throws an error if _state is "starting" but emitting not "running"
- test that "ensureInstance" calls "start" and starts normally
- change "instanceInfo" to be "protected"
- rename "instanceInfo" to "_instanceInfo"
- rename function "getInstanceInfo" to "instanceInfo"
- change "instanceInfo" to be an getter instead of an function
- change "_state" to be "protected"
- add getter function "state" to get the current state (return "_state")
- remove function "getPort" in favor of ".instanceInfo.port"
- remove function "getDbPath" in favor of ".instanceInfo.dbPath"
- remove function "getDbName" in favor of ".instanceInfo.dbName"