### PR TITLE
chore: change "target" to "es6"

### DIFF
--- a/packages/mongodb-memory-server-core/tsconfig.json
+++ b/packages/mongodb-memory-server-core/tsconfig.json
@@ -3,7 +3,7 @@
     "rootDir": "./src",
     "outDir": "./build",
     "noEmit": false,
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "sourceMap": true,
     "declaration": true,

--- a/packages/mongodb-memory-server-global-3.6/package.json
+++ b/packages/mongodb-memory-server-global-3.6/package.json
@@ -11,6 +11,9 @@
     "url": "https://github.com/nodkz/mongodb-memory-server.git",
     "directory": "packages/mongodb-memory-server-global-3.6"
   },
+  "engines": {
+    "node": ">=10.15.0"
+  },
   "homepage": "https://github.com/nodkz/mongodb-memory-server",
   "keywords": [
     "mongodb",

--- a/packages/mongodb-memory-server-global-4.2/package.json
+++ b/packages/mongodb-memory-server-global-4.2/package.json
@@ -11,6 +11,9 @@
     "url": "https://github.com/nodkz/mongodb-memory-server.git",
     "directory": "packages/mongodb-memory-server-global-4.2"
   },
+  "engines": {
+    "node": ">=10.15.0"
+  },
   "homepage": "https://github.com/nodkz/mongodb-memory-server",
   "keywords": [
     "mongodb",

--- a/packages/mongodb-memory-server-global-4.4/package.json
+++ b/packages/mongodb-memory-server-global-4.4/package.json
@@ -11,6 +11,9 @@
     "url": "https://github.com/nodkz/mongodb-memory-server.git",
     "directory": "packages/mongodb-memory-server-global-4.4"
   },
+  "engines": {
+    "node": ">=10.15.0"
+  },
   "homepage": "https://github.com/nodkz/mongodb-memory-server",
   "keywords": [
     "mongodb",

--- a/packages/mongodb-memory-server-global/package.json
+++ b/packages/mongodb-memory-server-global/package.json
@@ -10,6 +10,9 @@
     "url": "https://github.com/nodkz/mongodb-memory-server.git",
     "directory": "packages/mongodb-memory-server-global"
   },
+  "engines": {
+    "node": ">=10.15.0"
+  },
   "homepage": "https://github.com/nodkz/mongodb-memory-server",
   "keywords": [
     "mongodb",

--- a/packages/mongodb-memory-server/package.json
+++ b/packages/mongodb-memory-server/package.json
@@ -10,6 +10,9 @@
     "url": "https://github.com/nodkz/mongodb-memory-server.git",
     "directory": "packages/mongodb-memory-server"
   },
+  "engines": {
+    "node": ">=10.15.0"
+  },
   "homepage": "https://github.com/nodkz/mongodb-memory-server",
   "keywords": [
     "mongodb",


### PR DESCRIPTION
change compile target to `es6`

plus sides:
- reduces build size from `~360kb` to `~312kb` (core package)
- easier debug on problems (because the compiled code more resembles the source code)

down sides:
- not being able to run this package in an es5 engine anymore (this is so-or-so already thanks to `engines` and depended packages)

---

this is an separate PR from #396 because this might be an "major" change and debatable (at least from what i observed in typegoose)
main things i could observe (even with runtime warnings & documentation):
issues about "invalid syntax" errors (users tried to run typegoose in an non es6 environment (like nodejs before 10.15) (like #379 in this repository)

PS: documentation (like the other PR's for 7.0) will be added later