### PR TITLE
fix(MongoBinaryDownloadUrl): fix win32 download generation

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -77,7 +77,7 @@ export default class MongoBinaryDownloadUrl {
     if (!isNullOrUndefined(semver.coerce(this.version))) {
       if (semver.satisfies(this.version, '4.2.x')) {
         name += '-2012plus';
-      } else if (semver.lt(this.version, '4.0.0')) {
+      } else if (semver.lt(this.version, '4.1.0')) {
         name += '-2008plus-ssl';
       }
     }

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl-test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl-test.ts
@@ -92,6 +92,17 @@ describe('MongoBinaryDownloadUrl', () => {
         );
       });
 
+      it('4.0.14 (win32)', async () => {
+        const du = new MongoBinaryDownloadUrl({
+          platform: 'win32',
+          arch: 'x64',
+          version: '4.0.14',
+        });
+        expect(await du.getDownloadUrl()).toBe(
+          'https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.14.zip'
+        );
+      });
+
       it('4.2 (win32)', async () => {
         const du = new MongoBinaryDownloadUrl({
           platform: 'win32',


### PR DESCRIPTION
- add "-2008plus-ssl" if below version 4.1.0 and not just when below 4.0.0
- add test for win32 on version 4.0.14

## Related Issues

- fixes #399 

(base is master because this is an "hot-fix")