### PR TITLE
Fix/nameChanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ MONGOMS_MD5_CHECK=1 # if you want to make MD5 check of downloaded binary.
 MONGOMS_USE_LINUX_LSB_RELEASE # Only try "lsb_release -a"
 MONGOMS_USE_LINUX_OS_RELEASE # Only try to read "/etc/os-release"
 MONGOMS_USE_LINUX_ANYFILE_RELEASE # Only try to read the first file found "/etc/*-release"
+MONGOMS_ARCHIVE_NAME="mongodb-linux-x86_64-4.0.0.tgz" # Specify what file / archive to download
 ```
 
 ### Options which can be set via package.json's `config` section

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -119,15 +119,15 @@ export enum MongoMemoryReplSetStates {
 /**
  * All Events for "MongoMemoryReplSet"
  */
-export enum MongoMemoryReplSetEventEnum {
+export enum MongoMemoryReplSetEvents {
   stateChange = 'stateChange',
 }
 
 export interface MongoMemoryReplSet extends EventEmitter {
   // Overwrite EventEmitter's definitions (to provide at least the event names)
-  emit(event: MongoMemoryReplSetEventEnum, ...args: any[]): boolean;
-  on(event: MongoMemoryReplSetEventEnum, listener: (...args: any[]) => void): this;
-  once(event: MongoMemoryReplSetEventEnum, listener: (...args: any[]) => void): this;
+  emit(event: MongoMemoryReplSetEvents, ...args: any[]): boolean;
+  on(event: MongoMemoryReplSetEvents, listener: (...args: any[]) => void): this;
+  once(event: MongoMemoryReplSetEvents, listener: (...args: any[]) => void): this;
 }
 
 /**
@@ -161,7 +161,7 @@ export class MongoMemoryReplSet extends EventEmitter {
    */
   protected stateChange(newState: MongoMemoryReplSetStates, ...args: any[]): void {
     this._state = newState;
-    this.emit(MongoMemoryReplSetEventEnum.stateChange, newState, ...args);
+    this.emit(MongoMemoryReplSetEvents.stateChange, newState, ...args);
   }
 
   /**
@@ -421,11 +421,11 @@ export class MongoMemoryReplSet extends EventEmitter {
           function waitRunning(this: MongoMemoryReplSet, state: MongoMemoryReplSetStates) {
             // this is because other states can be emitted multiple times (like stopped & init for auth creation)
             if (state === MongoMemoryReplSetStates.running) {
-              this.removeListener(MongoMemoryReplSetEventEnum.stateChange, waitRunning);
+              this.removeListener(MongoMemoryReplSetEvents.stateChange, waitRunning);
               res();
             }
           }
-          this.on(MongoMemoryReplSetEventEnum.stateChange, waitRunning);
+          this.on(MongoMemoryReplSetEvents.stateChange, waitRunning);
         });
         return;
       case MongoMemoryReplSetStates.stopped:

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -94,7 +94,7 @@ export interface MongoInstanceData extends StartupInstanceData {
 /**
  * All Events for "MongoMemoryServer"
  */
-export enum MongoMemoryServerEventEnum {
+export enum MongoMemoryServerEvents {
   stateChange = 'stateChange',
 }
 
@@ -198,9 +198,9 @@ export interface MongoMemoryServerGetStartOptions {
 
 export interface MongoMemoryServer extends EventEmitter {
   // Overwrite EventEmitter's definitions (to provide at least the event names)
-  emit(event: MongoMemoryServerEventEnum, ...args: any[]): boolean;
-  on(event: MongoMemoryServerEventEnum, listener: (...args: any[]) => void): this;
-  once(event: MongoMemoryServerEventEnum, listener: (...args: any[]) => void): this;
+  emit(event: MongoMemoryServerEvents, ...args: any[]): boolean;
+  on(event: MongoMemoryServerEvents, listener: (...args: any[]) => void): this;
+  once(event: MongoMemoryServerEvents, listener: (...args: any[]) => void): this;
 }
 
 export class MongoMemoryServer extends EventEmitter {
@@ -243,7 +243,7 @@ export class MongoMemoryServer extends EventEmitter {
    */
   protected stateChange(newState: MongoMemoryServerStateEnum): void {
     this._state = newState;
-    this.emit(MongoMemoryServerEventEnum.stateChange, newState);
+    this.emit(MongoMemoryServerEvents.stateChange, newState);
   }
 
   /**
@@ -577,7 +577,7 @@ export class MongoMemoryServer extends EventEmitter {
         break;
       case MongoMemoryServerStateEnum.starting:
         return new Promise((res, rej) =>
-          this.once(MongoMemoryServerEventEnum.stateChange, (state) => {
+          this.once(MongoMemoryServerEvents.stateChange, (state) => {
             if (state != MongoMemoryServerStateEnum.running) {
               rej(
                 new Error(

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
@@ -5,7 +5,7 @@ import { MongoClient } from 'mongodb';
 import * as tmp from 'tmp';
 import MongoMemoryServer, {
   MongoMemoryServerEvents,
-  MongoMemoryServerStateEnum,
+  MongoMemoryServerStates,
 } from '../MongoMemoryServer';
 import MongoInstance from '../util/MongoInstance';
 import { assertion, isNullOrUndefined, statPath, uriTemplate } from '../util/utils';
@@ -265,7 +265,7 @@ describe('MongoMemoryServer', () => {
     it('should throw an error if state is not "new" or "stopped"', async () => {
       const mongoServer = new MongoMemoryServer();
       // @ts-expect-error
-      mongoServer._state = MongoMemoryServerStateEnum.starting;
+      mongoServer._state = MongoMemoryServerStates.starting;
       try {
         await mongoServer.start();
         fail('Expected "start" to fail');
@@ -311,7 +311,7 @@ describe('MongoMemoryServer', () => {
     it('should throw an error if "instanceInfo" is undefined but "_state" is "running"', async () => {
       const mongoServer = new MongoMemoryServer();
       // @ts-expect-error
-      mongoServer._state = MongoMemoryServerStateEnum.running;
+      mongoServer._state = MongoMemoryServerStates.running;
 
       try {
         await mongoServer.ensureInstance();
@@ -340,13 +340,13 @@ describe('MongoMemoryServer', () => {
     it('should throw an error if state was "starting" and emitted an event but not "running"', async () => {
       const mongoServer = new MongoMemoryServer();
       // @ts-expect-error
-      mongoServer._state = MongoMemoryServerStateEnum.starting;
+      mongoServer._state = MongoMemoryServerStates.starting;
       const ensureInstancePromise = mongoServer.ensureInstance();
 
-      mongoServer.emit(MongoMemoryServerEvents.stateChange, MongoMemoryServerStateEnum.stopped);
+      mongoServer.emit(MongoMemoryServerEvents.stateChange, MongoMemoryServerStates.stopped);
 
       expect(ensureInstancePromise).rejects.toThrow(
-        `"ensureInstance" waited for "running" but got an different state: "${MongoMemoryServerStateEnum.stopped}"`
+        `"ensureInstance" waited for "running" but got an different state: "${MongoMemoryServerStates.stopped}"`
       );
     });
 
@@ -448,7 +448,7 @@ describe('MongoMemoryServer', () => {
       expect(promises.stat).not.toHaveBeenCalled();
       expect(semver.lt).not.toHaveBeenCalled();
       expect(await statPath(dbPath)).toBeUndefined();
-      expect(mongoServer.state).toEqual(MongoMemoryServerStateEnum.new);
+      expect(mongoServer.state).toEqual(MongoMemoryServerStates.new);
       expect(mongoServer.instanceInfo).toBeUndefined();
     });
 
@@ -460,7 +460,7 @@ describe('MongoMemoryServer', () => {
       expect(promises.stat).toHaveBeenCalledTimes(1);
       expect(semver.lt).not.toHaveBeenCalled();
       expect(await statPath(dbPath)).toBeUndefined();
-      expect(mongoServer.state).toEqual(MongoMemoryServerStateEnum.new);
+      expect(mongoServer.state).toEqual(MongoMemoryServerStates.new);
       expect(mongoServer.instanceInfo).toBeUndefined();
     });
 
@@ -473,7 +473,7 @@ describe('MongoMemoryServer', () => {
       expect(promises.stat).toHaveBeenCalledTimes(1);
       expect(semver.lt).toHaveBeenCalledTimes(1);
       expect(await statPath(dbPath)).toBeUndefined();
-      expect(mongoServer.state).toEqual(MongoMemoryServerStateEnum.new);
+      expect(mongoServer.state).toEqual(MongoMemoryServerStates.new);
       expect(mongoServer.instanceInfo).toBeUndefined();
     });
   });
@@ -494,10 +494,10 @@ describe('MongoMemoryServer', () => {
 
   it('"state" should return correct state', () => {
     const mongoServer = new MongoMemoryServer();
-    expect(mongoServer.state).toEqual(MongoMemoryServerStateEnum.new);
+    expect(mongoServer.state).toEqual(MongoMemoryServerStates.new);
     // @ts-expect-error
-    mongoServer.stateChange(MongoMemoryServerStateEnum.running);
-    expect(mongoServer.state).toEqual(MongoMemoryServerStateEnum.running);
+    mongoServer.stateChange(MongoMemoryServerStates.running);
+    expect(mongoServer.state).toEqual(MongoMemoryServerStates.running);
   });
 
   it('"createAuth" should throw an error if called without "this.auth" defined', async () => {
@@ -527,6 +527,6 @@ describe('MongoMemoryServer', () => {
     await mongoServer.cleanup();
     expect(await statPath(dbPath)).toBeFalsy();
     expect(mongoServer.instanceInfo).toBeFalsy();
-    expect(mongoServer.state).toEqual(MongoMemoryServerStateEnum.new);
+    expect(mongoServer.state).toEqual(MongoMemoryServerStates.new);
   });
 });

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
@@ -4,7 +4,7 @@ import { promises } from 'fs';
 import { MongoClient } from 'mongodb';
 import * as tmp from 'tmp';
 import MongoMemoryServer, {
-  MongoMemoryServerEventEnum,
+  MongoMemoryServerEvents,
   MongoMemoryServerStateEnum,
 } from '../MongoMemoryServer';
 import MongoInstance from '../util/MongoInstance';
@@ -343,7 +343,7 @@ describe('MongoMemoryServer', () => {
       mongoServer._state = MongoMemoryServerStateEnum.starting;
       const ensureInstancePromise = mongoServer.ensureInstance();
 
-      mongoServer.emit(MongoMemoryServerEventEnum.stateChange, MongoMemoryServerStateEnum.stopped);
+      mongoServer.emit(MongoMemoryServerEvents.stateChange, MongoMemoryServerStateEnum.stopped);
 
       expect(ensureInstancePromise).rejects.toThrow(
         `"ensureInstance" waited for "running" but got an different state: "${MongoMemoryServerStateEnum.stopped}"`

--- a/packages/mongodb-memory-server-core/src/__tests__/replset-single.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-single.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import MongoMemoryReplSet, {
-  MongoMemoryReplSetEventEnum,
+  MongoMemoryReplSetEvents,
   MongoMemoryReplSetStates,
 } from '../MongoMemoryReplSet';
 import { MongoClient } from 'mongodb';
@@ -458,13 +458,13 @@ describe('MongoMemoryReplSet', () => {
     // @ts-expect-error
     replSet._state = MongoMemoryReplSetStates.stopped;
 
-    expect(replSet.listeners(MongoMemoryReplSetEventEnum.stateChange).length).toEqual(1);
+    expect(replSet.listeners(MongoMemoryReplSetEvents.stateChange).length).toEqual(1);
 
     replSet.start();
 
     await promise;
 
-    expect(replSet.listeners(MongoMemoryReplSetEventEnum.stateChange).length).toEqual(0);
+    expect(replSet.listeners(MongoMemoryReplSetEvents.stateChange).length).toEqual(0);
 
     await replSet.stop();
   });

--- a/packages/mongodb-memory-server-core/src/__tests__/replset-single.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-single.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import MongoMemoryReplSet, {
   MongoMemoryReplSetEventEnum,
-  MongoMemoryReplSetStateEnum,
+  MongoMemoryReplSetStates,
 } from '../MongoMemoryReplSet';
 import { MongoClient } from 'mongodb';
 import MongoMemoryServer from '../MongoMemoryServer';
@@ -56,10 +56,10 @@ describe('single server replset', () => {
   it('should be possible to connect replicaset after waitUntilRunning resolves', async () => {
     const replSet = new MongoMemoryReplSet();
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.init;
+    replSet._state = MongoMemoryReplSetStates.init;
     const promise = replSet.waitUntilRunning();
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.stopped;
+    replSet._state = MongoMemoryReplSetStates.stopped;
     replSet.start();
 
     await promise;
@@ -106,13 +106,13 @@ describe('single server replset', () => {
     }, 100);
 
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.init;
+    replSet._state = MongoMemoryReplSetStates.init;
     replSet.getUri();
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.running;
+    replSet._state = MongoMemoryReplSetStates.running;
     replSet.getUri();
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.stopped;
+    replSet._state = MongoMemoryReplSetStates.stopped;
 
     try {
       replSet.getUri();
@@ -131,7 +131,7 @@ describe('single server replset', () => {
 
     // this case can normally happen if "start" is called again, without either an error or "stop" happened
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.running; // artificially set this to running
+    replSet._state = MongoMemoryReplSetStates.running; // artificially set this to running
 
     try {
       await replSet.start();
@@ -158,7 +158,7 @@ describe('single server replset', () => {
     const replSet = new MongoMemoryReplSet();
     const spy = jest.spyOn(replSet, 'once');
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.running; // artificially set this to running to not actually have to start an server (test-speedup)
+    replSet._state = MongoMemoryReplSetStates.running; // artificially set this to running to not actually have to start an server (test-speedup)
 
     await replSet.waitUntilRunning();
 
@@ -173,7 +173,7 @@ describe('single server replset', () => {
 
     // this case can normally happen if "start" is called again, without either an error or "stop" happened
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.running; // artificially set this to running
+    replSet._state = MongoMemoryReplSetStates.running; // artificially set this to running
 
     try {
       // @ts-expect-error
@@ -192,7 +192,7 @@ describe('single server replset', () => {
     }, 100);
 
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.init; // artificially set this to init
+    replSet._state = MongoMemoryReplSetStates.init; // artificially set this to init
 
     try {
       // @ts-expect-error
@@ -290,12 +290,12 @@ describe('MongoMemoryReplSet', () => {
     it('"get state" should match "_state"', () => {
       // @ts-expect-error
       expect(replSet.state).toEqual(replSet._state);
-      expect(replSet.state).toEqual(MongoMemoryReplSetStateEnum.stopped);
+      expect(replSet.state).toEqual(MongoMemoryReplSetStates.stopped);
       // @ts-expect-error
-      replSet._state = MongoMemoryReplSetStateEnum.init;
+      replSet._state = MongoMemoryReplSetStates.init;
       // @ts-expect-error
       expect(replSet.state).toEqual(replSet._state);
-      expect(replSet.state).toEqual(MongoMemoryReplSetStateEnum.init);
+      expect(replSet.state).toEqual(MongoMemoryReplSetStates.init);
     });
 
     it('"binaryOpts" should match "_binaryOpts"', () => {
@@ -352,7 +352,7 @@ describe('MongoMemoryReplSet', () => {
     describe('state errors', () => {
       beforeEach(() => {
         // @ts-expect-error
-        replSet._state = MongoMemoryReplSetStateEnum.init;
+        replSet._state = MongoMemoryReplSetStates.init;
       });
       it('setter of "binaryOpts" should throw an error if state is not "stopped"', () => {
         try {
@@ -402,7 +402,7 @@ describe('MongoMemoryReplSet', () => {
     // this test creates an mock-instance, so that no actual instance gets started
     const replSet = new MongoMemoryReplSet();
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.running;
+    replSet._state = MongoMemoryReplSetStates.running;
     const instance = new MongoMemoryServer();
     jest.spyOn(instance, 'stop').mockRejectedValueOnce(new Error('Some Error'));
     replSet.servers = [instance];
@@ -452,11 +452,11 @@ describe('MongoMemoryReplSet', () => {
   it('"waitUntilRunning" should clear stateChange listener', async () => {
     const replSet = new MongoMemoryReplSet();
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.init;
+    replSet._state = MongoMemoryReplSetStates.init;
     const promise = replSet.waitUntilRunning();
     await utils.ensureAsync(); // ensure that "waitUntilRunning" has executed and setup the listener
     // @ts-expect-error
-    replSet._state = MongoMemoryReplSetStateEnum.stopped;
+    replSet._state = MongoMemoryReplSetStates.stopped;
 
     expect(replSet.listeners(MongoMemoryReplSetEventEnum.stateChange).length).toEqual(1);
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -66,8 +66,9 @@ export class MongoBinaryDownloadUrl {
       case 'windows':
         return this.getArchiveNameWin();
       case 'linux':
-      default:
         return this.getArchiveNameLinux();
+      default:
+        throw new Error(`Unkown Platform "${this.platform}"`);
     }
   }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -331,7 +331,7 @@ export class MongoBinaryDownloadUrl {
   }
 
   /**
-   * Translate input platform to mongodb useable platfrom
+   * Translate input platform to mongodb useable platform
    * @example
    * darwin -> osx
    * @param platform The Platform to translate
@@ -352,7 +352,7 @@ export class MongoBinaryDownloadUrl {
       case 'sunos':
         return 'sunos5';
       default:
-        throw new Error(`unsupported OS ${platform}`);
+        throw new Error(`Unkown Platform "${platform}"`);
     }
   }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -301,32 +301,24 @@ export class MongoBinaryDownloadUrl {
     let name = 'ubuntu';
     const ubuntuVer: string[] = os.release ? os.release.split('.') : [];
     const majorVer: number = parseInt(ubuntuVer[0], 10);
-    // const minorVer: string = ubuntuVer[1];
+    // for all cases where its just "10.10" -> "1010"
+    // and because the "04" version always exists for ubuntu, use that as default
+    let version = `${majorVer || 14}04`;
 
-    if (os.release === '12.04') {
-      name += '1204';
-    } else if (os.release === '14.04') {
-      name += '1404';
-    } else if (os.release === '14.10') {
-      name += '1410-clang';
-    } else if (majorVer === 14) {
-      name += '1404';
-    } else if (os.release === '16.04') {
-      name += '1604';
-    } else if (majorVer === 16) {
-      name += '1604';
+    if (os.release === '14.10') {
+      version = '1410-clang';
     } else if (majorVer >= 18) {
       if (this.version && this.version.indexOf('3.') === 0) {
-        // For MongoDB 3.x using 1604 binaries, download distro does not have builds for Ubuntu 1804
+        // For MongoDB 3.x using 1604 binaries, download distro does not have builds for Ubuntu 1804 AND 2004
         // https://www.mongodb.org/dl/linux/x86_64-ubuntu1604
-        name += '1604';
+        version = '1604';
       } else {
         // See fulllist of versions https://www.mongodb.org/dl/linux/x86_64-ubuntu1804
-        name += '1804';
+        // For MongoDB <4.4 using 1804 binaries, because 2004 dosnt have anything below 4.4
+        version = '1804';
       }
-    } else {
-      name += '1404';
     }
+    name += version;
     return name;
   }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -75,7 +75,7 @@ export class MongoBinaryDownloadUrl {
    * Get the archive for Windows
    * (from: https://www.mongodb.org/dl/win32)
    */
-  async getArchiveNameWin(): Promise<string> {
+  getArchiveNameWin(): string {
     let name = `mongodb-${this.platform}`;
     name += `-${this.arch}`;
     if (!isNullOrUndefined(semver.coerce(this.version))) {
@@ -93,7 +93,7 @@ export class MongoBinaryDownloadUrl {
    * Get the archive for OSX (Mac)
    * (from: https://www.mongodb.org/dl/osx)
    */
-  async getArchiveNameOsx(): Promise<string> {
+  getArchiveNameOsx(): string {
     let name = `mongodb-osx`;
     const version = semver.coerce(this.version);
     if (!isNullOrUndefined(version) && semver.gte(version, '3.2.0')) {

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -55,6 +55,10 @@ export class MongoBinaryDownloadUrl {
    * Version independent
    */
   async getArchiveName(): Promise<string> {
+    const archive_name = resolveConfig('ARCHIVE_NAME');
+    if (!isNullOrUndefined(archive_name) && archive_name.length > 0) {
+      return archive_name;
+    }
     switch (this.platform) {
       case 'osx':
         return this.getArchiveNameOsx();

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -369,8 +369,11 @@ export class MongoInstance extends EventEmitter {
    * @fires MongoInstance#instanceClosed
    */
   closeHandler(code: number): void {
-    if (code != 0) {
-      this.debug('Mongod instance closed with an non-0 code!');
+    // check if the platform is windows, if yes check if the code is not "12" or "0" otherwise just check code is not "0"
+    // because for mongodb any event on windows (like SIGINT / SIGTERM) will result in an code 12
+    // https://docs.mongodb.com/manual/reference/exit-codes/#12
+    if ((process.platform === 'win32' && code != 12 && code != 0) || code != 0) {
+      this.debug('Mongod instance closed with an non-0 (or non 12 on windows) code!');
     }
     this.debug(`CLOSE: ${code}`);
     this.emit(MongoInstanceEvents.instanceClosed, code);

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -1,4 +1,5 @@
 import MongoBinaryDownloadUrl from '../MongoBinaryDownloadUrl';
+import { setDefaultValue } from '../resolveConfig';
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -148,6 +149,17 @@ describe('MongoBinaryDownloadUrl', () => {
         'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.3.tgz'
       );
       expect(console.warn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should allow overwrite with "ARCHIVE_NAME"', async () => {
+      const archiveName = 'mongodb-linux-x86_64-4.0.0.tgz';
+      setDefaultValue('ARCHIVE_NAME', archiveName);
+      const du = new MongoBinaryDownloadUrl({
+        platform: 'linux',
+        arch: 'x64',
+        version: '3.6.3',
+      });
+      expect(await du.getDownloadUrl()).toBe(`https://fastdl.mongodb.org/linux/${archiveName}`);
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -178,6 +178,20 @@ describe('MongoBinaryDownloadUrl', () => {
         expect(err.message).toEqual('Unkown Platform "unkown"');
       }
     });
+
+    it('should throw an error if platform is unkown (translatePlatform)', async () => {
+      // this is to test the default case in "translatePlatform"
+      try {
+        new MongoBinaryDownloadUrl({
+          platform: 'unkown',
+          arch: 'x64',
+          version: '4.0.0',
+        });
+        fail('Expected "translatePlatform" to throw');
+      } catch (err) {
+        expect(err.message).toEqual('Unkown Platform "unkown"');
+      }
+    });
   });
 
   describe('getUbuntuVersionString()', () => {

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -250,6 +250,26 @@ describe('MongoBinaryDownloadUrl', () => {
       ).toBe('ubuntu1804');
       downloadUrl.version = oldMongoVersion;
     });
+    it('should return a archive name for Ubuntu 20.04', () => {
+      const oldMongoVersion = downloadUrl.version;
+      downloadUrl.version = '3.6.3';
+      expect(
+        downloadUrl.getUbuntuVersionString({
+          os: 'linux',
+          dist: 'Ubuntu Linux',
+          release: '20.04',
+        })
+      ).toBe('ubuntu1604');
+      downloadUrl.version = '4.0.1';
+      expect(
+        downloadUrl.getUbuntuVersionString({
+          os: 'linux',
+          dist: 'Ubuntu Linux',
+          release: '20.04',
+        })
+      ).toBe('ubuntu1804');
+      downloadUrl.version = oldMongoVersion;
+    });
   });
 
   describe('getDebianVersionString()', () => {

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -1,5 +1,5 @@
 import MongoBinaryDownloadUrl from '../MongoBinaryDownloadUrl';
-import { setDefaultValue } from '../resolveConfig';
+import { defaultValues, setDefaultValue } from '../resolveConfig';
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -160,6 +160,23 @@ describe('MongoBinaryDownloadUrl', () => {
         version: '3.6.3',
       });
       expect(await du.getDownloadUrl()).toBe(`https://fastdl.mongodb.org/linux/${archiveName}`);
+      defaultValues.delete('ARCHIVE_NAME');
+    });
+
+    it('should throw an error if platform is unkown (getArchiveName)', async () => {
+      // this is to test the default case in "getArchiveName"
+      const du = new MongoBinaryDownloadUrl({
+        platform: 'linux',
+        arch: 'x64',
+        version: '4.0.0',
+      });
+      du.platform = 'unkown';
+      try {
+        await du.getArchiveName();
+        fail('Expected "getArchiveName" to throw');
+      } catch (err) {
+        expect(err.message).toEqual('Unkown Platform "unkown"');
+      }
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
+++ b/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
@@ -5,7 +5,7 @@ import debug from 'debug';
 const log = debug('MongoMS:ResolveConfig');
 
 const ENV_CONFIG_PREFIX = 'MONGOMS_';
-const defaultValues = new Map<string, string>();
+export const defaultValues = new Map<string, string>();
 
 /**
  * Set an Default value for an specific key


### PR DESCRIPTION
- fix(MongoInstance): handle code `12` on windows
- refactor(MongoMemoryReplSet): setup proper events
- rename `MongoMemoryReplSetStateEnum` to `MongoMemoryReplSetStates`
- rename `MongoMemoryReplSetEventEnum` to `MongoMemoryReplSetEvents`
- rename `MongoMemoryServerEventEnum` to `MongoMemoryServerEvents`
- rename `MongoMemoryServerStateEnum` to `MongoMemoryServerStates`
- allow overwrite of archiveName
- refactor(MongoBinaryDownloadUrl): remove "async" where not needed
- getArchiveName: throw error if platform is unkown
- translatePlatform: change default error
- add test for "ubuntu2004"
- minify "getUbuntuVersionString"

## Related Issues

- closes #411 
- closes #295 

---

as an note: it seems like codecov is having problems again (unable to find report / processing...)