### PR TITLE
Fix/improveCode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,13 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 0,
     '@typescript-eslint/no-use-before-define': 0,
     '@typescript-eslint/no-empty-function': 0,
-    'curly': ['error', 'all']
+    'curly': ['error', 'all'],
+    'padding-line-between-statements': [
+      "warn",
+      {
+        blankLine: 'always', prev: '*', next: 'return'
+      }
+    ]
   },
   env: {
     node: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
   rules: {
     'no-underscore-dangle': 0,
     'arrow-body-style': 0,
-    'no-unused-expressions': 0,
+    'no-unused-expressions': 1,
     'no-plusplus': 0,
     'no-console': 0,
     'func-names': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,7 +63,16 @@ module.exports = {
       },
       {
         blankLine: 'always', prev: ['function', 'class'], next: '*' // add blank line *after* all functions and classes
-      }
+      },
+      {
+        blankLine: 'always', prev: '*', next: 'import' // add blank line *before* all imports
+      },
+      {
+        blankLine: 'always', prev: 'import', next: '*' // add blank line *after* all imports
+      },
+      {
+        blankLine: 'never', prev: 'import', next: 'import' // dont allow blank line between imports
+      },
     ]
   },
   env: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
     ],
     'no-prototype-builtins': 0,
     'prefer-destructuring': 0,
-    'no-else-return': 0,
+    'no-else-return': 1,
     'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
     '@typescript-eslint/explicit-member-accessibility': 0,
     '@typescript-eslint/no-explicit-any': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
     'curly': ['error', 'all']
   },
   env: {
+    node: true,
     jest: true,
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
         objects: 'always-multiline',
         imports: 'always-multiline',
         exports: 'always-multiline',
-        functions: 'ignore',
+        functions: 'never',
       },
     ],
     'no-prototype-builtins': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,7 +47,16 @@ module.exports = {
     'padding-line-between-statements': [
       "warn",
       {
-        blankLine: 'always', prev: '*', next: 'return'
+        blankLine: 'always', prev: '*', next: 'return' // add blank line *before* all returns (if there are statements before)
+      },
+      {
+        blankLine: 'always', prev: '*', next: 'if' // add blank line *before* all ifs
+      },
+      {
+        blankLine: 'always', prev: 'if', next: '*' // add blank line *after* all ifs
+      },
+      {
+        blankLine: 'any', prev: 'if', next: 'if' // allow blank line between ifs, but not enforce either
       }
     ]
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,12 @@ module.exports = {
       },
       {
         blankLine: 'any', prev: 'if', next: 'if' // allow blank line between ifs, but not enforce either
+      },
+      {
+        blankLine: 'always', prev: '*', next: ['function', 'class'] // add blank line *before* all functions and classes
+      },
+      {
+        blankLine: 'always', prev: ['function', 'class'], next: '*' // add blank line *after* all functions and classes
       }
     ]
   },

--- a/README.md
+++ b/README.md
@@ -284,11 +284,11 @@ MONGOMS_MD5_CHECK=1 # if you want to make MD5 check of downloaded binary.
 # Passed constructor parameter `binary.checkMD5` has higher priority.
 
 # GetOS specific ones (for linux only)
-MONGOMS_USE_LINUX_LSB_RELEASE=any # Only try "lsb_release -a"
-MONGOMS_USE_LINUX_OS_RELEASE=any # Only try to read "/etc/os-release"
-MONGOMS_USE_LINUX_ANYFILE_RELEASE=any # Only try to read the first file found "/etc/*-release"
+MONGOMS_USE_LINUX_LSB_RELEASE=1 # Only try "lsb_release -a"
+MONGOMS_USE_LINUX_OS_RELEASE=1 # Only try to read "/etc/os-release"
+MONGOMS_USE_LINUX_ANYFILE_RELEASE=1 # Only try to read the first file found "/etc/*-release"
 MONGOMS_ARCHIVE_NAME="mongodb-linux-x86_64-4.0.0.tgz" # Specify what file / archive to download
-MONGOMS_SKIP_OS_RELEASE=any # ignore error thrown in "tryOSRelease"
+MONGOMS_SKIP_OS_RELEASE=1 # ignore error thrown in "tryOSRelease"
 ```
 
 ### Options which can be set via package.json's `config` section

--- a/README.md
+++ b/README.md
@@ -268,14 +268,14 @@ const replSet = new MongoMemoryReplSet({
 
 ### Options which can be set via ENVIRONMENT variables
 
-*`=any` means if value is defined at all*
+*`=1` means booleans, allowed values for booleans are: (case-insensitive) `1 on yes true`*
 
 ```sh
 MONGOMS_DOWNLOAD_DIR=/path/to/mongodb/binaries
 MONGOMS_PLATFORM=linux
 MONGOMS_ARCH=x64
 MONGOMS_VERSION=3
-MONGOMS_DEBUG=1 # also available case-insensitive values: "on" "yes" "true"
+MONGOMS_DEBUG=1 # enable debug for all MongoMS files
 MONGOMS_DOWNLOAD_MIRROR=host # your mirror host to download the mongodb binary
 MONGOMS_DOWNLOAD_URL=url # full URL to download the mongodb binary
 MONGOMS_DISABLE_POSTINSTALL=1 # if you want to skip download binaries on `npm i` command

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ MONGOMS_USE_LINUX_LSB_RELEASE # Only try "lsb_release -a"
 MONGOMS_USE_LINUX_OS_RELEASE # Only try to read "/etc/os-release"
 MONGOMS_USE_LINUX_ANYFILE_RELEASE # Only try to read the first file found "/etc/*-release"
 MONGOMS_ARCHIVE_NAME="mongodb-linux-x86_64-4.0.0.tgz" # Specify what file / archive to download
+SKIP_OS_RELEASE # ignore error thrown in "tryOSRelease"
 ```
 
 ### Options which can be set via package.json's `config` section

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ const replSet = new MongoMemoryReplSet({
 
 ### Options which can be set via ENVIRONMENT variables
 
+*`=any` means if value is defined at all*
+
 ```sh
 MONGOMS_DOWNLOAD_DIR=/path/to/mongodb/binaries
 MONGOMS_PLATFORM=linux
@@ -282,11 +284,11 @@ MONGOMS_MD5_CHECK=1 # if you want to make MD5 check of downloaded binary.
 # Passed constructor parameter `binary.checkMD5` has higher priority.
 
 # GetOS specific ones (for linux only)
-MONGOMS_USE_LINUX_LSB_RELEASE # Only try "lsb_release -a"
-MONGOMS_USE_LINUX_OS_RELEASE # Only try to read "/etc/os-release"
-MONGOMS_USE_LINUX_ANYFILE_RELEASE # Only try to read the first file found "/etc/*-release"
+MONGOMS_USE_LINUX_LSB_RELEASE=any # Only try "lsb_release -a"
+MONGOMS_USE_LINUX_OS_RELEASE=any # Only try to read "/etc/os-release"
+MONGOMS_USE_LINUX_ANYFILE_RELEASE=any # Only try to read the first file found "/etc/*-release"
 MONGOMS_ARCHIVE_NAME="mongodb-linux-x86_64-4.0.0.tgz" # Specify what file / archive to download
-SKIP_OS_RELEASE # ignore error thrown in "tryOSRelease"
+MONGOMS_SKIP_OS_RELEASE=any # ignore error thrown in "tryOSRelease"
 ```
 
 ### Options which can be set via package.json's `config` section

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -171,6 +171,7 @@ export class MongoMemoryReplSet extends EventEmitter {
   static async create(opts: Partial<MongoMemoryReplSetOpts> = {}): Promise<MongoMemoryReplSet> {
     const replSet = new this({ ...opts });
     await replSet.start();
+
     return replSet;
   }
 
@@ -277,6 +278,7 @@ export class MongoMemoryReplSet extends EventEmitter {
       opts.storageEngine = baseOpts.storageEngine;
     }
     log('   instance opts:', opts);
+
     return opts;
   }
 
@@ -305,9 +307,11 @@ export class MongoMemoryReplSet extends EventEmitter {
     const ports = this.servers.map((s) => {
       const port = s.instanceInfo?.port;
       assertion(!isNullOrUndefined(port), new Error('Instance Port is undefined!'));
+
       return port;
     });
     const hosts = ports.map((port) => `127.0.0.1:${port}`).join(',');
+
     return `mongodb://${hosts}/${dbName}?replicaSet=${this._replSetOpts.name}`;
   }
 
@@ -369,14 +373,17 @@ export class MongoMemoryReplSet extends EventEmitter {
     if (this._state === MongoMemoryReplSetStates.stopped) {
       return false;
     }
+
     return Promise.all(this.servers.map((s) => s.stop(false)))
       .then(() => {
         this.stateChange(MongoMemoryReplSetStates.stopped);
+
         return true;
       })
       .catch((err) => {
         log(err);
         this.stateChange(MongoMemoryReplSetStates.stopped, err);
+
         return false;
       });
   }
@@ -427,6 +434,7 @@ export class MongoMemoryReplSet extends EventEmitter {
           }
           this.on(MongoMemoryReplSetEvents.stateChange, waitRunning);
         });
+
         return;
       case MongoMemoryReplSetStates.stopped:
       default:
@@ -547,6 +555,7 @@ export class MongoMemoryReplSet extends EventEmitter {
       auth: typeof this.replSetOpts.auth === 'object' ? this.replSetOpts.auth : undefined,
     };
     const server = new MongoMemoryServer(serverOpts);
+
     return server;
   }
 

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -435,6 +435,7 @@ export class MongoMemoryReplSet extends EventEmitter {
               res();
             }
           }
+
           this.on(MongoMemoryReplSetEvents.stateChange, waitRunning);
         });
 

--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -265,6 +265,7 @@ export class MongoMemoryReplSet extends EventEmitter {
       replSet: this._replSetOpts.name,
       storageEngine: this._replSetOpts.storageEngine,
     };
+
     if (baseOpts.args) {
       opts.args = (this._replSetOpts.args || []).concat(baseOpts.args);
     }
@@ -277,6 +278,7 @@ export class MongoMemoryReplSet extends EventEmitter {
     if (baseOpts.storageEngine) {
       opts.storageEngine = baseOpts.storageEngine;
     }
+
     log('   instance opts:', opts);
 
     return opts;
@@ -370,6 +372,7 @@ export class MongoMemoryReplSet extends EventEmitter {
   async stop(): Promise<boolean> {
     log('stop' + isNullOrUndefined(process.exitCode) ? '' : ': called by process-event');
     process.removeListener('beforeExit', this.stop); // many accumulate inside tests
+
     if (this._state === MongoMemoryReplSetStates.stopped) {
       return false;
     }
@@ -572,9 +575,11 @@ export class MongoMemoryReplSet extends EventEmitter {
         (server) =>
           new Promise((res, rej) => {
             const instanceInfo = server.instanceInfo;
+
             if (!instanceInfo) {
               return rej(new Error('_waitForPrimary - instanceInfo not present '));
             }
+
             instanceInfo.instance.once(MongoInstanceEvents.instancePrimary, res);
 
             if (instanceInfo.instance.isInstancePrimary) {

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -282,6 +282,7 @@ export class MongoMemoryServer extends EventEmitter {
       if (!debug.enabled('MongoMS:MongoMemoryServer')) {
         console.warn('Starting the instance failed, enable debug for more infomation');
       }
+
       throw err;
     });
 
@@ -384,11 +385,13 @@ export class MongoMemoryServer extends EventEmitter {
 
     if (!isNullOrUndefined(this._instanceInfo)) {
       log('_startUpInstance: "instanceInfo" already defined, reusing instance');
+
       if (!forceSamePort) {
         const newPort = await this.getNewPort(this._instanceInfo.port);
         this._instanceInfo.instance.instanceOpts.port = newPort;
         this._instanceInfo.port = newPort;
       }
+
       await this._instanceInfo.instance.run();
 
       return;
@@ -498,16 +501,19 @@ export class MongoMemoryServer extends EventEmitter {
     if (typeof force !== 'boolean') {
       force = false;
     }
+
     assertion(
       this.state === MongoMemoryServerStates.stopped,
       new Error('Cannot cleanup when state is not "stopped"')
     );
     process.removeListener('beforeExit', this.cleanup);
+
     if (isNullOrUndefined(this._instanceInfo)) {
       log('cleanup: "instanceInfo" is undefined');
 
       return;
     }
+
     assertion(
       isNullOrUndefined(this._instanceInfo.instance.childProcess),
       new Error('Cannot cleanup because "instance.childProcess" is still defined')
@@ -516,6 +522,7 @@ export class MongoMemoryServer extends EventEmitter {
     log(`cleanup: force ${force}`);
 
     const tmpDir = this._instanceInfo.tmpDir;
+
     if (!isNullOrUndefined(tmpDir)) {
       log(`cleanup: removing tmpDir at ${tmpDir.name}`);
       tmpDir.removeCallback();
@@ -574,6 +581,7 @@ export class MongoMemoryServer extends EventEmitter {
         if (this._instanceInfo) {
           return this._instanceInfo;
         }
+
         throw new Error('MongoMemoryServer "_state" is "running" but "instanceInfo" is undefined!');
       case MongoMemoryServerStates.new:
       case MongoMemoryServerStates.stopped:
@@ -588,6 +596,7 @@ export class MongoMemoryServer extends EventEmitter {
                 )
               );
             }
+
             res(this._instanceInfo);
           })
         );
@@ -670,6 +679,7 @@ export class MongoMemoryServer extends EventEmitter {
 
       for (const user of this.auth.extraUsers) {
         user.database = isNullOrUndefined(user.database) ? 'admin' : user.database;
+
         // just to have not to call "con.db" everytime in the loop if its the same
         if (user.database !== db.databaseName) {
           db = con.db(user.database);

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -21,10 +21,6 @@ import { promises as fspromises } from 'fs';
 import { MongoClient } from 'mongodb';
 import { lt } from 'semver';
 
-// this is because "import {promises: {readdir}}" is not valid syntax
-// const { readdir, stat, rmdir } = promises;
-// the statement above cannot be done, because otherwise in the tests no spy / mock can be applied
-
 const log = debug('MongoMS:MongoMemoryServer');
 
 tmp.setGracefulCleanup();

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -448,11 +448,13 @@ export class MongoMemoryServer extends EventEmitter {
     // just return "true" if there was never an instance
     if (isNullOrUndefined(this._instanceInfo)) {
       log('"instanceInfo" is not defined (never ran?)');
+
       return true;
     }
 
     if (this._state === MongoMemoryServerStates.stopped) {
       log(`stop: state is "stopped", so already stopped`);
+
       return true;
     }
 
@@ -503,6 +505,7 @@ export class MongoMemoryServer extends EventEmitter {
     process.removeListener('beforeExit', this.cleanup);
     if (isNullOrUndefined(this._instanceInfo)) {
       log('cleanup: "instanceInfo" is undefined');
+
       return;
     }
     assertion(
@@ -661,6 +664,7 @@ export class MongoMemoryServer extends EventEmitter {
         if (a.database === 'admin') {
           return -1; // try to make all "admin" at the start of the array
         }
+
         return a.database === b.database ? 0 : 1; // "0" to sort same databases continuesly, "-1" if nothing before/above applies
       });
 

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { promises } from 'fs';
+import { promises as fspromises } from 'fs';
 import { MongoClient } from 'mongodb';
 import * as tmp from 'tmp';
 import MongoMemoryServer, {
@@ -432,7 +432,7 @@ describe('MongoMemoryServer', () => {
   describe('cleanup()', () => {
     // "beforeAll" dosnt work here, thanks to the top-level "afterAll" hook
     beforeEach(() => {
-      jest.spyOn(promises, 'stat');
+      jest.spyOn(fspromises, 'stat');
       // @ts-expect-error because "default" dosnt exist in the definitions
       jest.spyOn(semver.default, 'lt'); // it needs to be ".default" otherwise "lt" is only an getter
     });
@@ -442,7 +442,7 @@ describe('MongoMemoryServer', () => {
       const dbPath = mongoServer.instanceInfo!.dbPath;
       await mongoServer.stop(false);
       await mongoServer.cleanup();
-      expect(promises.stat).not.toHaveBeenCalled();
+      expect(fspromises.stat).not.toHaveBeenCalled();
       expect(semver.lt).not.toHaveBeenCalled();
       expect(await statPath(dbPath)).toBeUndefined();
       expect(mongoServer.state).toEqual(MongoMemoryServerStates.new);
@@ -454,7 +454,7 @@ describe('MongoMemoryServer', () => {
       const dbPath = mongoServer.instanceInfo!.dbPath;
       await mongoServer.stop(false);
       await mongoServer.cleanup(true);
-      expect(promises.stat).toHaveBeenCalledTimes(1);
+      expect(fspromises.stat).toHaveBeenCalledTimes(1);
       expect(semver.lt).not.toHaveBeenCalled();
       expect(await statPath(dbPath)).toBeUndefined();
       expect(mongoServer.state).toEqual(MongoMemoryServerStates.new);
@@ -467,7 +467,7 @@ describe('MongoMemoryServer', () => {
       const dbPath = mongoServer.instanceInfo!.dbPath;
       await mongoServer.stop(false);
       await mongoServer.cleanup(true);
-      expect(promises.stat).toHaveBeenCalledTimes(1);
+      expect(fspromises.stat).toHaveBeenCalledTimes(1);
       expect(semver.lt).toHaveBeenCalledTimes(1);
       expect(await statPath(dbPath)).toBeUndefined();
       expect(mongoServer.state).toEqual(MongoMemoryServerStates.new);

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { promises } from 'fs';
 import { MongoClient } from 'mongodb';
 import * as tmp from 'tmp';
@@ -264,7 +263,7 @@ describe('MongoMemoryServer', () => {
 
     it('should throw an error if state is not "new" or "stopped"', async () => {
       const mongoServer = new MongoMemoryServer();
-      // @ts-expect-error
+      // @ts-expect-error because "_state" is protected
       mongoServer._state = MongoMemoryServerStates.starting;
       try {
         await mongoServer.start();
@@ -277,8 +276,7 @@ describe('MongoMemoryServer', () => {
     it('should throw error on start if there is already a running instance', async () => {
       const mongoServer2 = new MongoMemoryServer();
       // this case can normally happen if "start" is called again
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
+      // @ts-expect-error because "_instanceInfo" is protected
       mongoServer2._instanceInfo = { instance: { childProcess: {} } } as any; // artificially set this to {} to not be undefined anymore
       await expect(mongoServer2.start()).rejects.toThrow(
         'Cannot start because "instance.childProcess" is already defined!'
@@ -310,7 +308,7 @@ describe('MongoMemoryServer', () => {
 
     it('should throw an error if "instanceInfo" is undefined but "_state" is "running"', async () => {
       const mongoServer = new MongoMemoryServer();
-      // @ts-expect-error
+      // @ts-expect-error because "_state" is protected
       mongoServer._state = MongoMemoryServerStates.running;
 
       try {
@@ -325,8 +323,7 @@ describe('MongoMemoryServer', () => {
 
     it('should throw an error if the given "_state" has no case', async () => {
       const mongoServer = new MongoMemoryServer();
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
+      // @ts-expect-error because "_state" is protected
       mongoServer._state = 'not Existing';
 
       try {
@@ -339,7 +336,7 @@ describe('MongoMemoryServer', () => {
 
     it('should throw an error if state was "starting" and emitted an event but not "running"', async () => {
       const mongoServer = new MongoMemoryServer();
-      // @ts-expect-error
+      // @ts-expect-error because "_state" is protected
       mongoServer._state = MongoMemoryServerStates.starting;
       const ensureInstancePromise = mongoServer.ensureInstance();
 
@@ -436,7 +433,7 @@ describe('MongoMemoryServer', () => {
     // "beforeAll" dosnt work here, thanks to the top-level "afterAll" hook
     beforeEach(() => {
       jest.spyOn(promises, 'stat');
-      // @ts-expect-error
+      // @ts-expect-error because "default" dosnt exist in the definitions
       jest.spyOn(semver.default, 'lt'); // it needs to be ".default" otherwise "lt" is only an getter
     });
 
@@ -495,7 +492,7 @@ describe('MongoMemoryServer', () => {
   it('"state" should return correct state', () => {
     const mongoServer = new MongoMemoryServer();
     expect(mongoServer.state).toEqual(MongoMemoryServerStates.new);
-    // @ts-expect-error
+    // @ts-expect-error because "stateChange" is protected
     mongoServer.stateChange(MongoMemoryServerStates.running);
     expect(mongoServer.state).toEqual(MongoMemoryServerStates.running);
   });
@@ -504,7 +501,7 @@ describe('MongoMemoryServer', () => {
     const mongoServer = new MongoMemoryServer();
 
     try {
-      // @ts-expect-error
+      // @ts-expect-error because "createAuth" is protected
       await mongoServer.createAuth();
       fail('Expected "createAuth" to fail');
     } catch (err) {

--- a/packages/mongodb-memory-server-core/src/__tests__/replset-multi.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-multi.test.ts
@@ -23,7 +23,7 @@ describe('multi-member replica set', () => {
     // await while all SECONDARIES will be ready
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    const db = await con.db(replSet.replSetOpts.dbName);
+    const db = await con.db('admin');
     const admin = db.admin();
     const status = await admin.replSetGetStatus();
     expect(status.members.filter((m: any) => m.stateStr === 'PRIMARY')).toHaveLength(1);

--- a/packages/mongodb-memory-server-core/src/__tests__/replset-single.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/replset-single.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import MongoMemoryReplSet, {
   MongoMemoryReplSetEvents,
   MongoMemoryReplSetStates,
@@ -55,10 +54,10 @@ describe('single server replset', () => {
 
   it('should be possible to connect replicaset after waitUntilRunning resolves', async () => {
     const replSet = new MongoMemoryReplSet();
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.init;
     const promise = replSet.waitUntilRunning();
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.stopped;
     replSet.start();
 
@@ -105,13 +104,13 @@ describe('single server replset', () => {
       fail('Timeout - Expected "getUri" to throw');
     }, 100);
 
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.init;
     replSet.getUri();
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.running;
     replSet.getUri();
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.stopped;
 
     try {
@@ -130,7 +129,7 @@ describe('single server replset', () => {
     }, 100);
 
     // this case can normally happen if "start" is called again, without either an error or "stop" happened
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.running; // artificially set this to running
 
     try {
@@ -147,7 +146,6 @@ describe('single server replset', () => {
     await replSet.start();
 
     expect(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       replSet.servers[0].opts.instance!.args!.findIndex((x) => x === '--quiet') > -1
     ).toBeTruthy();
 
@@ -156,13 +154,13 @@ describe('single server replset', () => {
 
   it('"waitUntilRunning" should return if state is "running"', async () => {
     const replSet = new MongoMemoryReplSet();
-    const spy = jest.spyOn(replSet, 'once');
-    // @ts-expect-error
+    jest.spyOn(replSet, 'once');
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.running; // artificially set this to running to not actually have to start an server (test-speedup)
 
     await replSet.waitUntilRunning();
 
-    expect(spy.mock.calls.length).toEqual(0);
+    expect(replSet.once).not.toHaveBeenCalled();
   });
 
   it('"_initReplSet" should throw an error if _state is not "init"', async () => {
@@ -172,11 +170,11 @@ describe('single server replset', () => {
     }, 100);
 
     // this case can normally happen if "start" is called again, without either an error or "stop" happened
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.running; // artificially set this to running
 
     try {
-      // @ts-expect-error
+      // @ts-expect-error because "_initReplSet" is protected
       await replSet._initReplSet();
       fail('Expected "_initReplSet" to throw');
     } catch (err) {
@@ -191,11 +189,11 @@ describe('single server replset', () => {
       fail('Timeout - Expected "_initReplSet" to throw');
     }, 100);
 
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.init; // artificially set this to init
 
     try {
-      // @ts-expect-error
+      // @ts-expect-error because "_initReplSet" is protected
       await replSet._initReplSet();
       fail('Expected "_initReplSet" to throw');
     } catch (err) {
@@ -205,7 +203,7 @@ describe('single server replset', () => {
   });
 
   it('should make use of "AutomaticAuth" (ephemeralForTest)', async () => {
-    // @ts-expect-error
+    // @ts-expect-error because "initAllServers" is protected
     jest.spyOn(MongoMemoryReplSet.prototype, 'initAllServers');
     jest.spyOn(console, 'warn').mockImplementationOnce(() => void 0);
     const replSet = await MongoMemoryReplSet.create({
@@ -235,7 +233,7 @@ describe('single server replset', () => {
     });
     expect(users.users).toHaveLength(1);
     expect(users.users[0].user).toEqual(replSet.replSetOpts.auth.customRootName);
-    // @ts-expect-error
+    // @ts-expect-error because "initAllServers" is protected
     expect(MongoMemoryReplSet.prototype.initAllServers).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledTimes(1);
 
@@ -244,7 +242,7 @@ describe('single server replset', () => {
   });
 
   it('should make use of "AutomaticAuth" (wiredTiger)', async () => {
-    // @ts-expect-error
+    // @ts-expect-error because "initAllServers" is protected
     jest.spyOn(MongoMemoryReplSet.prototype, 'initAllServers');
     const replSet = await MongoMemoryReplSet.create({
       replSet: { auth: {}, count: 3, storageEngine: 'wiredTiger' },
@@ -273,7 +271,7 @@ describe('single server replset', () => {
     });
     expect(users.users).toHaveLength(1);
     expect(users.users[0].user).toEqual(replSet.replSetOpts.auth.customRootName);
-    // @ts-expect-error
+    // @ts-expect-error because "initAllServers" is protected
     expect(MongoMemoryReplSet.prototype.initAllServers).toHaveBeenCalledTimes(2);
 
     await con.close();
@@ -288,39 +286,39 @@ describe('MongoMemoryReplSet', () => {
       replSet = new MongoMemoryReplSet();
     });
     it('"get state" should match "_state"', () => {
-      // @ts-expect-error
+      // @ts-expect-error because "_state" is protected
       expect(replSet.state).toEqual(replSet._state);
       expect(replSet.state).toEqual(MongoMemoryReplSetStates.stopped);
-      // @ts-expect-error
+      // @ts-expect-error because "_state" is protected
       replSet._state = MongoMemoryReplSetStates.init;
-      // @ts-expect-error
+      // @ts-expect-error because "_state" is protected
       expect(replSet.state).toEqual(replSet._state);
       expect(replSet.state).toEqual(MongoMemoryReplSetStates.init);
     });
 
     it('"binaryOpts" should match "_binaryOpts"', () => {
-      // @ts-expect-error
+      // @ts-expect-error because "_binaryOpts" is protected
       expect(replSet.binaryOpts).toEqual(replSet._binaryOpts);
       expect(replSet.binaryOpts).toEqual({});
       replSet.binaryOpts = { arch: 'x86_64' };
-      // @ts-expect-error
+      // @ts-expect-error because "_binaryOpts" is protected
       expect(replSet.binaryOpts).toEqual(replSet._binaryOpts);
       expect(replSet.binaryOpts).toEqual({ arch: 'x86_64' });
     });
 
     it('"instanceOpts" should match "_instanceOpts"', () => {
-      // @ts-expect-error
+      // @ts-expect-error because "_instanceOpts" is protected
       expect(replSet.instanceOpts).toEqual(replSet._instanceOpts);
       expect(replSet.instanceOpts).toEqual([]);
       replSet.instanceOpts = [{ port: 1001 }];
-      // @ts-expect-error
+      // @ts-expect-error because "_instanceOpts" is protected
       expect(replSet.instanceOpts).toEqual(replSet._instanceOpts);
       expect(replSet.instanceOpts).toEqual([{ port: 1001 }]);
       expect(replSet.instanceOpts).toHaveLength(1);
     });
 
     it('"replSetOpts" should match "_replSetOpts"', () => {
-      // @ts-expect-error
+      // @ts-expect-error because "_replSetOpts" is protected
       expect(replSet.replSetOpts).toEqual(replSet._replSetOpts);
       expect(replSet.replSetOpts).toEqual({
         auth: false,
@@ -334,7 +332,7 @@ describe('MongoMemoryReplSet', () => {
         configSettings: {},
       });
       replSet.replSetOpts = { auth: true };
-      // @ts-expect-error
+      // @ts-expect-error because "_replSetOpts" is protected
       expect(replSet.replSetOpts).toEqual(replSet._replSetOpts);
       expect(replSet.replSetOpts).toEqual({
         auth: true,
@@ -351,7 +349,7 @@ describe('MongoMemoryReplSet', () => {
 
     describe('state errors', () => {
       beforeEach(() => {
-        // @ts-expect-error
+        // @ts-expect-error because "_state" is protected
         replSet._state = MongoMemoryReplSetStates.init;
       });
       it('setter of "binaryOpts" should throw an error if state is not "stopped"', () => {
@@ -401,7 +399,7 @@ describe('MongoMemoryReplSet', () => {
   it('"stop" should return "false" if an error got thrown', async () => {
     // this test creates an mock-instance, so that no actual instance gets started
     const replSet = new MongoMemoryReplSet();
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.running;
     const instance = new MongoMemoryServer();
     jest.spyOn(instance, 'stop').mockRejectedValueOnce(new Error('Some Error'));
@@ -415,7 +413,7 @@ describe('MongoMemoryReplSet', () => {
     const replSet = new MongoMemoryReplSet();
 
     try {
-      // @ts-expect-error
+      // @ts-expect-error because "_waitForPrimary" is protected
       await replSet._waitForPrimary(1); // 1ms to be fast (0 and 1 are equal for "setTimeout" in js)
       fail('Expected "_waitForPrimary" to throw');
     } catch (err) {
@@ -426,7 +424,7 @@ describe('MongoMemoryReplSet', () => {
   it('"getInstanceOpts" should return "storageEngine" if in baseOpts', () => {
     const replSet = new MongoMemoryReplSet();
 
-    // @ts-expect-error
+    // @ts-expect-error because "getInstanceOpts" is protected
     expect(replSet.getInstanceOpts({ storageEngine: 'wiredTiger' })).toMatchObject<
       MongoMemoryInstanceProp // this is needed, otherwise no ts error when "storageEngine" might get changed
     >({
@@ -451,11 +449,11 @@ describe('MongoMemoryReplSet', () => {
 
   it('"waitUntilRunning" should clear stateChange listener', async () => {
     const replSet = new MongoMemoryReplSet();
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.init;
     const promise = replSet.waitUntilRunning();
     await utils.ensureAsync(); // ensure that "waitUntilRunning" has executed and setup the listener
-    // @ts-expect-error
+    // @ts-expect-error because "_state" is protected
     replSet._state = MongoMemoryReplSetStates.stopped;
 
     expect(replSet.listeners(MongoMemoryReplSetEvents.stateChange).length).toEqual(1);

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -107,6 +107,7 @@ export class MongoBinary {
       typeof cachePath === 'string',
       new Error(`No Cache Path for version "${version}" found (and download failed silently?)`)
     );
+
     return cachePath;
   }
 
@@ -200,6 +201,7 @@ export class MongoBinary {
     }
 
     log(`MongoBinary: Mongod binary path: "${binaryPath}"`);
+
     return binaryPath;
   }
 }

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -1,4 +1,4 @@
-import { promises } from 'fs';
+import { promises, constants } from 'fs';
 import os from 'os';
 import path from 'path';
 import LockFile from 'lockfile';
@@ -36,7 +36,7 @@ export class MongoBinary {
     let binaryPath = '';
 
     try {
-      await promises.access(systemBinary);
+      await promises.access(systemBinary, constants.X_OK); // check if the provided path exists and has the execute bit for current user
 
       log(`MongoBinary: found system binary path at "${systemBinary}"`);
       binaryPath = systemBinary;

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -48,14 +48,6 @@ export class MongoBinary {
   }
 
   /**
-   * Check if specified version already exists in the cache
-   * @param version The Version to check for
-   */
-  static getCachePath(version: string): string | undefined {
-    return this.cache.get(version);
-  }
-
-  /**
    * Probe download path and download the binary
    * @param options Options Configuring which binary to download and to which path
    * @returns The BinaryPath the binary has been downloaded to
@@ -87,7 +79,7 @@ export class MongoBinary {
     });
 
     // check cache if it got already added to the cache
-    if (!this.getCachePath(version)) {
+    if (!this.cache.get(version)) {
       const downloader = new MongoBinaryDownload({
         downloadDir,
         platform,
@@ -109,7 +101,7 @@ export class MongoBinary {
       });
     });
 
-    const cachePath = this.getCachePath(version);
+    const cachePath = this.cache.get(version);
     // ensure that "path" exists, so the return type does not change
     assertion(
       typeof cachePath === 'string',
@@ -194,7 +186,7 @@ export class MongoBinary {
     );
 
     if (!binaryPath) {
-      binaryPath = this.getCachePath(options.version);
+      binaryPath = this.cache.get(options.version);
     }
 
     if (!binaryPath) {

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -1,4 +1,4 @@
-import { promises, constants } from 'fs';
+import { promises as fspromises, constants } from 'fs';
 import os from 'os';
 import path from 'path';
 import LockFile from 'lockfile';
@@ -36,7 +36,7 @@ export class MongoBinary {
     let binaryPath = '';
 
     try {
-      await promises.access(systemBinary, constants.X_OK); // check if the provided path exists and has the execute bit for current user
+      await fspromises.access(systemBinary, constants.X_OK); // check if the provided path exists and has the execute bit for current user
 
       log(`MongoBinary: found system binary path at "${systemBinary}"`);
       binaryPath = systemBinary;

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -1,11 +1,10 @@
-import fs from 'fs';
+import { existsSync, promises } from 'fs';
 import os from 'os';
 import path from 'path';
 import LockFile from 'lockfile';
 import mkdirp from 'mkdirp';
 import findCacheDir from 'find-cache-dir';
 import { execSync } from 'child_process';
-import { promisify } from 'util';
 import MongoBinaryDownload from './MongoBinaryDownload';
 import resolveConfig, { envToBool, ResolveConfigVariables } from './resolveConfig';
 import debug from 'debug';
@@ -37,7 +36,7 @@ export class MongoBinary {
     let binaryPath = '';
 
     try {
-      await promisify(fs.access)(systemBinary);
+      await promises.access(systemBinary);
 
       log(`MongoBinary: found system binary path at "${systemBinary}"`);
       binaryPath = systemBinary;
@@ -138,7 +137,7 @@ export class MongoBinary {
     const defaultOptions = {
       downloadDir:
         resolveConfig(ResolveConfigVariables.DOWNLOAD_DIR) ||
-        (fs.existsSync(legacyDLDir)
+        (existsSync(legacyDLDir)
           ? legacyDLDir
           : path.resolve(
               findCacheDir({

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -89,6 +89,7 @@ export class MongoBinary {
       });
       this.cache.set(version, await downloader.getMongodPath());
     }
+
     // remove lock
     await new Promise((res) => {
       LockFile.unlock(lockfile, (err) => {
@@ -154,6 +155,7 @@ export class MongoBinary {
 
     if (options.systemBinary) {
       binaryPath = await this.getSystemPath(options.systemBinary);
+
       if (binaryPath) {
         if (binaryPath.indexOf(' ') >= 0) {
           binaryPath = `"${binaryPath}"`;

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises } from 'fs';
+import { promises } from 'fs';
 import os from 'os';
 import path from 'path';
 import LockFile from 'lockfile';
@@ -8,7 +8,7 @@ import { execSync } from 'child_process';
 import MongoBinaryDownload from './MongoBinaryDownload';
 import resolveConfig, { envToBool, ResolveConfigVariables } from './resolveConfig';
 import debug from 'debug';
-import { assertion, isNullOrUndefined } from './utils';
+import { assertion, isNullOrUndefined, pathExists } from './utils';
 
 const log = debug('MongoMS:MongoBinary');
 
@@ -137,7 +137,7 @@ export class MongoBinary {
     const defaultOptions = {
       downloadDir:
         resolveConfig(ResolveConfigVariables.DOWNLOAD_DIR) ||
-        (existsSync(legacyDLDir)
+        ((await pathExists(legacyDLDir))
           ? legacyDLDir
           : path.resolve(
               findCacheDir({

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -7,7 +7,7 @@ import findCacheDir from 'find-cache-dir';
 import { execSync } from 'child_process';
 import { promisify } from 'util';
 import MongoBinaryDownload from './MongoBinaryDownload';
-import resolveConfig, { envToBool } from './resolveConfig';
+import resolveConfig, { envToBool, ResolveConfigVariables } from './resolveConfig';
 import debug from 'debug';
 import { assertion } from './utils';
 
@@ -142,7 +142,7 @@ export class MongoBinary {
     // "||" is still used here, because it should default if the value is false-y (like an empty string)
     const defaultOptions = {
       downloadDir:
-        resolveConfig('DOWNLOAD_DIR') ||
+        resolveConfig(ResolveConfigVariables.DOWNLOAD_DIR) ||
         (fs.existsSync(legacyDLDir)
           ? legacyDLDir
           : path.resolve(
@@ -152,11 +152,11 @@ export class MongoBinary {
               }) || '',
               'mongodb-binaries'
             )),
-      platform: resolveConfig('PLATFORM') || os.platform(),
-      arch: resolveConfig('ARCH') || os.arch(),
-      version: resolveConfig('VERSION') || LATEST_VERSION,
-      systemBinary: resolveConfig('SYSTEM_BINARY'),
-      checkMD5: envToBool(resolveConfig('MD5_CHECK')),
+      platform: resolveConfig(ResolveConfigVariables.PLATFORM) || os.platform(),
+      arch: resolveConfig(ResolveConfigVariables.ARCH) || os.arch(),
+      version: resolveConfig(ResolveConfigVariables.VERSION) || LATEST_VERSION,
+      systemBinary: resolveConfig(ResolveConfigVariables.SYSTEM_BINARY),
+      checkMD5: envToBool(resolveConfig(ResolveConfigVariables.MD5_CHECK)),
     };
 
     /** Provided Options combined with the Default Options */

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -11,7 +11,7 @@ import MongoBinaryDownloadUrl from './MongoBinaryDownloadUrl';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import resolveConfig, { envToBool, ResolveConfigVariables } from './resolveConfig';
 import debug from 'debug';
-import { assertion } from './utils';
+import { assertion, pathExists } from './utils';
 
 const log = debug('MongoMS:MongoBinaryDownload');
 
@@ -76,7 +76,7 @@ export class MongoBinaryDownload {
     const binaryName = this.platform === 'win32' ? 'mongod.exe' : 'mongod';
     const mongodPath = path.resolve(this.downloadDir, this.version, binaryName);
 
-    if (await this.locationExists(mongodPath)) {
+    if (await pathExists(mongodPath)) {
       return mongodPath;
     }
 
@@ -84,7 +84,7 @@ export class MongoBinaryDownload {
     await this.extract(mongoDBArchive);
     await promises.unlink(mongoDBArchive);
 
-    if (await this.locationExists(mongodPath)) {
+    if (await pathExists(mongodPath)) {
       return mongodPath;
     }
 
@@ -185,7 +185,7 @@ export class MongoBinaryDownload {
     const tempDownloadLocation = path.resolve(this.downloadDir, `${filename}.downloading`);
     log(`Downloading${proxy ? ` via proxy ${proxy}` : ''}: "${downloadUrl}"`);
 
-    if (await this.locationExists(downloadLocation)) {
+    if (await pathExists(downloadLocation)) {
       log('Already downloaded archive found, skipping download');
       return downloadLocation;
     }
@@ -235,7 +235,7 @@ export class MongoBinaryDownload {
       );
     }
 
-    if (!(await this.locationExists(path.resolve(this.downloadDir, this.version, binaryName)))) {
+    if (!(await pathExists(path.resolve(this.downloadDir, this.version, binaryName)))) {
       throw new Error(
         `MongoBinaryDownload: missing mongod binary in ${mongoDBArchive} (downloaded from ${
           this._downloadingUrl ?? 'unkown'
@@ -433,23 +433,6 @@ export class MongoBinaryDownload {
       process.stdout.write(message);
     } else {
       console.log(message);
-    }
-  }
-
-  /**
-   * Test if the location given is already used
-   * Does *not* dereference links
-   * @param location The Path to test
-   */
-  async locationExists(location: string): Promise<boolean> {
-    try {
-      await promises.lstat(location);
-      return true;
-    } catch (e) {
-      if (e.code !== 'ENOENT') {
-        throw e;
-      }
-      return false;
     }
   }
 }

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -120,6 +120,10 @@ export class MongoBinaryDownload {
    * Download MD5 file and check it against the MongoDB Archive
    * @param urlForReferenceMD5 URL to download the MD5
    * @param mongoDBArchive The MongoDB Archive file location
+   *
+   * @returns {undefined} if "checkMD5" is falsey
+   * @returns {true} if the md5 check was successful
+   * @throws if the md5 check failed
    */
   async makeMD5check(
     urlForReferenceMD5: string,

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import url from 'url';
 import path from 'path';
-import { promises, existsSync, createWriteStream, createReadStream } from 'fs';
+import { promises, createWriteStream, createReadStream } from 'fs';
 import md5File from 'md5-file';
 import https from 'https';
 import { createUnzip } from 'zlib';
@@ -102,7 +102,7 @@ export class MongoBinaryDownload {
       version: this.version,
     });
 
-    if (!existsSync(this.downloadDir)) {
+    if (!(await pathExists(this.downloadDir))) {
       await promises.mkdir(this.downloadDir);
     }
 
@@ -210,7 +210,7 @@ export class MongoBinaryDownload {
     const extractDir = path.resolve(this.downloadDir, this.version);
     log(`extract(): ${extractDir}`);
 
-    if (!existsSync(extractDir)) {
+    if (!(await pathExists(extractDir))) {
       promises.mkdir(extractDir);
     }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import url from 'url';
 import path from 'path';
-import { promises, createWriteStream, createReadStream } from 'fs';
+import { promises, createWriteStream, createReadStream, constants } from 'fs';
 import md5File from 'md5-file';
 import https from 'https';
 import { createUnzip } from 'zlib';
@@ -104,6 +104,16 @@ export class MongoBinaryDownload {
 
     if (!(await pathExists(this.downloadDir))) {
       await promises.mkdir(this.downloadDir);
+    }
+
+    try {
+      await promises.access(this.downloadDir, constants.X_OK | constants.W_OK); // check that this process has permissions to create files & modify file contents & read file contents
+    } catch (err) {
+      console.error(
+        `Download Directory at "${this.downloadDir}" does not have sufficient permissions to be used by this process\n` +
+          'Needed Permissions: Write & Execute (-wx)\n'
+      );
+      throw err;
     }
 
     const downloadUrl = await mbdUrl.getDownloadUrl();

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -8,11 +8,11 @@ import { createUnzip } from 'zlib';
 import tar from 'tar-stream';
 import yauzl from 'yauzl';
 import MongoBinaryDownloadUrl from './MongoBinaryDownloadUrl';
-import { LATEST_VERSION } from './MongoBinary';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { promisify } from 'util';
 import resolveConfig, { envToBool, ResolveConfigVariables } from './resolveConfig';
 import debug from 'debug';
+import { assertion } from './utils';
 
 const log = debug('MongoMS:MongoBinaryDownload');
 
@@ -56,7 +56,9 @@ export class MongoBinaryDownload {
   constructor({ platform, arch, downloadDir, version, checkMD5 }: MongoBinaryDownloadOpts) {
     this.platform = platform ?? os.platform();
     this.arch = arch ?? os.arch();
-    this.version = version ?? LATEST_VERSION;
+    version = version ?? resolveConfig(ResolveConfigVariables.VERSION);
+    assertion(typeof version === 'string', new Error('"version" is not an string!'));
+    this.version = version;
     this.downloadDir = path.resolve(downloadDir || 'mongodb-download');
     this.checkMD5 = checkMD5 ?? envToBool(resolveConfig(ResolveConfigVariables.MD5_CHECK));
     this.dlProgress = {

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import url from 'url';
 import path from 'path';
-import { promises, createWriteStream, createReadStream, constants } from 'fs';
+import { promises as fspromises, createWriteStream, createReadStream, constants } from 'fs';
 import md5File from 'md5-file';
 import https from 'https';
 import { createUnzip } from 'zlib';
@@ -82,7 +82,7 @@ export class MongoBinaryDownload {
 
     const mongoDBArchive = await this.startDownload();
     await this.extract(mongoDBArchive);
-    await promises.unlink(mongoDBArchive);
+    await fspromises.unlink(mongoDBArchive);
 
     if (await pathExists(mongodPath)) {
       return mongodPath;
@@ -103,11 +103,11 @@ export class MongoBinaryDownload {
     });
 
     if (!(await pathExists(this.downloadDir))) {
-      await promises.mkdir(this.downloadDir);
+      await fspromises.mkdir(this.downloadDir);
     }
 
     try {
-      await promises.access(this.downloadDir, constants.X_OK | constants.W_OK); // check that this process has permissions to create files & modify file contents & read file contents
+      await fspromises.access(this.downloadDir, constants.X_OK | constants.W_OK); // check that this process has permissions to create files & modify file contents & read file contents
     } catch (err) {
       console.error(
         `Download Directory at "${this.downloadDir}" does not have sufficient permissions to be used by this process\n` +
@@ -144,7 +144,7 @@ export class MongoBinaryDownload {
 
     log('Checking MD5 of downloaded binary...');
     const mongoDBArchiveMd5 = await this.download(urlForReferenceMD5);
-    const signatureContent = (await promises.readFile(mongoDBArchiveMd5)).toString('utf-8');
+    const signatureContent = (await fspromises.readFile(mongoDBArchiveMd5)).toString('utf-8');
     const m = signatureContent.match(/(.*?)\s/);
     const md5Remote = m ? m[1] : null;
     const md5Local = md5File.sync(mongoDBArchive);
@@ -227,7 +227,7 @@ export class MongoBinaryDownload {
     log(`extract(): ${extractDir}`);
 
     if (!(await pathExists(extractDir))) {
-      promises.mkdir(extractDir);
+      fspromises.mkdir(extractDir);
     }
 
     let filter: (file: string) => boolean;
@@ -419,7 +419,7 @@ export class MongoBinaryDownload {
             }
 
             fileStream.close();
-            await promises.rename(tempDownloadLocation, downloadLocation);
+            await fspromises.rename(tempDownloadLocation, downloadLocation);
             log(`moved ${tempDownloadLocation} to ${downloadLocation}`);
 
             resolve(downloadLocation);

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -151,6 +151,7 @@ export class MongoBinaryDownload {
     if (md5Remote !== md5Local) {
       throw new Error('MongoBinaryDownload: md5 check failed');
     }
+
     return true;
   }
 
@@ -197,6 +198,7 @@ export class MongoBinaryDownload {
 
     if (await pathExists(downloadLocation)) {
       log('Already downloaded archive found, skipping download');
+
       return downloadLocation;
     }
 
@@ -207,6 +209,7 @@ export class MongoBinaryDownload {
       downloadLocation,
       tempDownloadLocation
     );
+
     return downloadedFile;
   }
 
@@ -252,6 +255,7 @@ export class MongoBinaryDownload {
         }). Broken archive from MongoDB Provider?`
       );
     }
+
     return extractDir;
   }
 
@@ -370,13 +374,16 @@ export class MongoBinaryDownload {
                     '  https://www.mongodb.org/dl/win32 for Windows'
                 )
               );
+
               return;
             }
             reject(new Error('Status Code isnt 200!'));
+
             return;
           }
           if (typeof response.headers['content-length'] != 'string') {
             reject(new Error('Response header "content-length" is empty!'));
+
             return;
           }
           this.dlProgress.current = 0;
@@ -397,6 +404,7 @@ export class MongoBinaryDownload {
                   `Too small (${this.dlProgress.current} bytes) mongod binary downloaded from ${downloadUrl}`
                 )
               );
+
               return;
             }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -141,6 +141,7 @@ export class MongoBinaryDownload {
     if (!this.checkMD5) {
       return undefined;
     }
+
     log('Checking MD5 of downloaded binary...');
     const mongoDBArchiveMd5 = await this.download(urlForReferenceMD5);
     const signatureContent = (await promises.readFile(mongoDBArchiveMd5)).toString('utf-8');
@@ -148,6 +149,7 @@ export class MongoBinaryDownload {
     const md5Remote = m ? m[1] : null;
     const md5Local = md5File.sync(mongoDBArchive);
     log(`Local MD5: ${md5Local}, Remote MD5: ${md5Remote}`);
+
     if (md5Remote !== md5Local) {
       throw new Error('MongoBinaryDownload: md5 check failed');
     }
@@ -188,6 +190,7 @@ export class MongoBinaryDownload {
     };
 
     const filename = (urlObject.pathname || '').split('/').pop();
+
     if (!filename) {
       throw new Error(`MongoBinaryDownload: missing filename for url ${downloadUrl}`);
     }
@@ -228,6 +231,7 @@ export class MongoBinaryDownload {
     }
 
     let filter: (file: string) => boolean;
+
     if (this.platform === 'win32') {
       filter = (file: string) => {
         return /bin\/mongod.exe$/.test(file) || /.dll$/.test(file);
@@ -279,6 +283,7 @@ export class MongoBinaryDownload {
           })
         );
       }
+
       stream.on('end', () => next());
       stream.resume();
     });
@@ -318,6 +323,7 @@ export class MongoBinaryDownload {
         if (e || !zipfile) {
           return reject(e);
         }
+
         zipfile.readEntry();
 
         zipfile.on('end', () => resolve());
@@ -326,10 +332,12 @@ export class MongoBinaryDownload {
           if (!filter(entry.fileName)) {
             return zipfile.readEntry();
           }
+
           zipfile.openReadStream(entry, (e, r) => {
             if (e || !r) {
               return reject(e);
             }
+
             r.on('end', () => zipfile.readEntry());
             r.pipe(
               createWriteStream(path.resolve(extractDir, path.basename(entry.fileName)), {
@@ -377,6 +385,7 @@ export class MongoBinaryDownload {
 
               return;
             }
+
             reject(new Error('Status Code isnt 200!'));
 
             return;
@@ -386,6 +395,7 @@ export class MongoBinaryDownload {
 
             return;
           }
+
           this.dlProgress.current = 0;
           this.dlProgress.length = parseInt(response.headers['content-length'], 10);
           this.dlProgress.totalMb = Math.round((this.dlProgress.length / 1048576) * 10) / 10;
@@ -435,9 +445,11 @@ export class MongoBinaryDownload {
     this.dlProgress.current += chunk.length;
 
     const now = Date.now();
+
     if (now - this.dlProgress.lastPrintedAt < 2000) {
       return;
     }
+
     this.dlProgress.lastPrintedAt = now;
 
     const percentComplete =
@@ -446,6 +458,7 @@ export class MongoBinaryDownload {
 
     const crReturn = this.platform === 'win32' ? '\x1b[0G' : '\r';
     const message = `Downloading MongoDB ${this.version}: ${percentComplete} % (${mbComplete}mb / ${this.dlProgress.totalMb}mb)${crReturn}`;
+
     if (process.stdout.isTTY) {
       // if TTY overwrite last line over and over until finished
       process.stdout.write(message);

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -11,7 +11,7 @@ import MongoBinaryDownloadUrl from './MongoBinaryDownloadUrl';
 import { LATEST_VERSION } from './MongoBinary';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { promisify } from 'util';
-import resolveConfig, { envToBool } from './resolveConfig';
+import resolveConfig, { envToBool, ResolveConfigVariables } from './resolveConfig';
 import debug from 'debug';
 
 const log = debug('MongoMS:MongoBinaryDownload');
@@ -58,7 +58,7 @@ export class MongoBinaryDownload {
     this.arch = arch ?? os.arch();
     this.version = version ?? LATEST_VERSION;
     this.downloadDir = path.resolve(downloadDir || 'mongodb-download');
-    this.checkMD5 = checkMD5 ?? envToBool(resolveConfig('MD5_CHECK'));
+    this.checkMD5 = checkMD5 ?? envToBool(resolveConfig(ResolveConfigVariables.MD5_CHECK));
     this.dlProgress = {
       current: 0,
       length: 0,

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -1,6 +1,6 @@
 import getOS, { AnyOS, LinuxOS } from './getos';
 import { execSync } from 'child_process';
-import resolveConfig from './resolveConfig';
+import resolveConfig, { ResolveConfigVariables } from './resolveConfig';
 import debug from 'debug';
 import * as semver from 'semver';
 import { isNullOrUndefined } from './utils';
@@ -38,13 +38,14 @@ export class MongoBinaryDownloadUrl {
     const archive = await this.getArchiveName();
     log(`Using "${archive}" as the Archive String`);
 
-    const downloadUrl = resolveConfig('DOWNLOAD_URL');
+    const downloadUrl = resolveConfig(ResolveConfigVariables.DOWNLOAD_URL);
     if (downloadUrl) {
       log(`Using "${downloadUrl}" as the Download-URL`);
       return downloadUrl;
     }
 
-    const mirror = resolveConfig('DOWNLOAD_MIRROR') ?? 'https://fastdl.mongodb.org';
+    const mirror =
+      resolveConfig(ResolveConfigVariables.DOWNLOAD_MIRROR) ?? 'https://fastdl.mongodb.org';
     log(`Using "${mirror}" as the mirror`);
 
     return `${mirror}/${this.platform}/${archive}`;
@@ -55,7 +56,7 @@ export class MongoBinaryDownloadUrl {
    * Version independent
    */
   async getArchiveName(): Promise<string> {
-    const archive_name = resolveConfig('ARCHIVE_NAME');
+    const archive_name = resolveConfig(ResolveConfigVariables.ARCHIVE_NAME);
     if (!isNullOrUndefined(archive_name) && archive_name.length > 0) {
       return archive_name;
     }

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -39,6 +39,7 @@ export class MongoBinaryDownloadUrl {
     log(`Using "${archive}" as the Archive String`);
 
     const downloadUrl = resolveConfig(ResolveConfigVariables.DOWNLOAD_URL);
+
     if (downloadUrl) {
       log(`Using "${downloadUrl}" as the Download-URL`);
 
@@ -58,9 +59,11 @@ export class MongoBinaryDownloadUrl {
    */
   async getArchiveName(): Promise<string> {
     const archive_name = resolveConfig(ResolveConfigVariables.ARCHIVE_NAME);
+
     if (!isNullOrUndefined(archive_name) && archive_name.length > 0) {
       return archive_name;
     }
+
     switch (this.platform) {
       case 'osx':
         return this.getArchiveNameOsx();
@@ -81,6 +84,7 @@ export class MongoBinaryDownloadUrl {
   getArchiveNameWin(): string {
     let name = `mongodb-${this.platform}`;
     name += `-${this.arch}`;
+
     if (!isNullOrUndefined(semver.coerce(this.version))) {
       if (semver.satisfies(this.version, '4.2.x')) {
         name += '-2012plus';
@@ -88,6 +92,7 @@ export class MongoBinaryDownloadUrl {
         name += '-2008plus-ssl';
       }
     }
+
     name += `-${this.version}.zip`;
 
     return name;
@@ -100,12 +105,14 @@ export class MongoBinaryDownloadUrl {
   getArchiveNameOsx(): string {
     let name = `mongodb-osx`;
     const version = semver.coerce(this.version);
+
     if (!isNullOrUndefined(version) && semver.gte(version, '3.2.0')) {
       name += '-ssl';
     }
     if (isNullOrUndefined(version) || semver.gte(version, '4.2.0')) {
       name = `mongodb-macos`; // somehow these files are not listed in https://www.mongodb.org/dl/osx
     }
+
     name += `-${this.arch}`;
     name += `-${this.version}.tgz`;
 
@@ -121,10 +128,12 @@ export class MongoBinaryDownloadUrl {
     name += `-${this.arch}`;
 
     let osString: string | undefined;
+
     if (this.arch !== 'i686') {
       if (!this.os) {
         this.os = await getOS();
       }
+
       osString = this.getLinuxOSVersionString(this.os as LinuxOS);
     }
     if (osString) {
@@ -168,6 +177,7 @@ export class MongoBinaryDownloadUrl {
       // warn if no case for the *parsed* distro is found
       console.warn(`Unknown linux distro ${os.dist}`);
     }
+
     // warn for the fallback
     console.warn(`Falling back to legacy MongoDB build!`);
 
@@ -181,6 +191,7 @@ export class MongoBinaryDownloadUrl {
   getDebianVersionString(os: LinuxOS): string {
     let name = 'debian';
     const release: number = parseFloat(os.release);
+
     if (release >= 10 || os.release === 'unstable') {
       name += '10';
     } else if (release >= 9) {
@@ -201,6 +212,7 @@ export class MongoBinaryDownloadUrl {
   getFedoraVersionString(os: LinuxOS): string {
     let name = 'rhel';
     const fedoraVer: number = parseInt(os.release, 10);
+
     if (fedoraVer > 18) {
       name += '70';
     } else if (fedoraVer < 19 && fedoraVer >= 12) {
@@ -219,6 +231,7 @@ export class MongoBinaryDownloadUrl {
   getRhelVersionString(os: LinuxOS): string {
     let name = 'rhel';
     const { release } = os;
+
     if (release) {
       if (/^8/.test(release)) {
         name += '80';
@@ -260,6 +273,7 @@ export class MongoBinaryDownloadUrl {
   getMintVersionString(os: LinuxOS): string {
     let name = 'ubuntu';
     const mintMajorVer = parseInt(os.release ? os.release.split('.')[0] : os.release);
+
     if (mintMajorVer < 17) {
       throw new Error('Mint Versions under 17 are not supported!');
     }
@@ -326,6 +340,7 @@ export class MongoBinaryDownloadUrl {
         version = '1804';
       }
     }
+
     name += version;
 
     return name;
@@ -343,6 +358,7 @@ export class MongoBinaryDownloadUrl {
         return 'osx';
       case 'win32':
         const version = semver.coerce(this.version);
+
         if (isNullOrUndefined(version)) {
           return 'windows';
         }
@@ -371,6 +387,7 @@ export class MongoBinaryDownloadUrl {
       } else if (mongoPlatform === 'win32') {
         return 'i386';
       }
+
       throw new Error('unsupported architecture');
     } else if (arch === 'x64') {
       return 'x86_64';

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -41,6 +41,7 @@ export class MongoBinaryDownloadUrl {
     const downloadUrl = resolveConfig(ResolveConfigVariables.DOWNLOAD_URL);
     if (downloadUrl) {
       log(`Using "${downloadUrl}" as the Download-URL`);
+
       return downloadUrl;
     }
 
@@ -88,6 +89,7 @@ export class MongoBinaryDownloadUrl {
       }
     }
     name += `-${this.version}.zip`;
+
     return name;
   }
 
@@ -106,6 +108,7 @@ export class MongoBinaryDownloadUrl {
     }
     name += `-${this.arch}`;
     name += `-${this.version}.tgz`;
+
     return name;
   }
 
@@ -187,6 +190,7 @@ export class MongoBinaryDownloadUrl {
     } else if (release >= 7.1) {
       name += '71';
     }
+
     return name;
   }
 
@@ -204,6 +208,7 @@ export class MongoBinaryDownloadUrl {
     } else if (fedoraVer < 12 && fedoraVer >= 6) {
       name += '55';
     }
+
     return name;
   }
 
@@ -225,6 +230,7 @@ export class MongoBinaryDownloadUrl {
         name += '55';
       }
     }
+
     return name;
   }
 
@@ -321,6 +327,7 @@ export class MongoBinaryDownloadUrl {
       }
     }
     name += version;
+
     return name;
   }
 
@@ -339,6 +346,7 @@ export class MongoBinaryDownloadUrl {
         if (isNullOrUndefined(version)) {
           return 'windows';
         }
+
         return semver.gte(version, '4.3.0') ? 'windows' : 'win32';
       case 'linux':
       case 'elementary OS':

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -146,6 +146,7 @@ export class MongoInstance extends EventEmitter {
    */
   static async run(opts: Partial<MongodOpts>): Promise<MongoInstance> {
     const instance = new this(opts);
+
     return instance.run();
   }
 
@@ -221,6 +222,7 @@ export class MongoInstance extends EventEmitter {
 
     await launch;
     this.emit(MongoInstanceEvents.instanceStarted);
+
     return this;
   }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -167,6 +167,7 @@ export class MongoInstance extends EventEmitter {
     // "!!" converts the value to an boolean (double-invert) so that no "falsy" values are added
     result.push('--port', this.instanceOpts.port.toString());
     result.push('--dbpath', this.instanceOpts.dbPath);
+
     if (!!this.instanceOpts.storageEngine) {
       result.push('--storageEngine', this.instanceOpts.storageEngine);
     }
@@ -278,6 +279,7 @@ export class MongoInstance extends EventEmitter {
           }
         }
       }
+
       await killProcess(this.childProcess, 'childProcess');
       this.childProcess = undefined; // reset reference to the childProcess for "mongod"
     } else {
@@ -387,6 +389,7 @@ export class MongoInstance extends EventEmitter {
     if ((process.platform === 'win32' && code != 12 && code != 0) || code != 0) {
       this.debug('Mongod instance closed with an non-0 (or non 12 on windows) code!');
     }
+
     this.debug(`CLOSE: ${code}`);
     this.emit(MongoInstanceEvents.instanceClosed, code);
   }

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -8,7 +8,7 @@ import { assertion, uriTemplate, isNullOrUndefined, killProcess } from './utils'
 import { lt } from 'semver';
 import { EventEmitter } from 'events';
 import { MongoClient, MongoNetworkError } from 'mongodb';
-import { promises, constants } from 'fs';
+import { promises as fspromises, constants } from 'fs';
 
 if (lt(process.version, '10.15.0')) {
   console.warn('Using NodeJS below 10.15.0');
@@ -210,7 +210,7 @@ export class MongoInstance extends EventEmitter {
 
     const mongoBin = await MongoBinary.getPath(this.binaryOpts);
     try {
-      await promises.access(mongoBin, constants.X_OK);
+      await fspromises.access(mongoBin, constants.X_OK);
     } catch (err) {
       console.error(
         `Mongod File at "${mongoBin}" does not have sufficient permissions to be used by this process\n` +

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
@@ -1,8 +1,10 @@
 import * as tmp from 'tmp';
 import fs from 'fs';
 import os from 'os';
-import MongoBinary, { LATEST_VERSION } from '../MongoBinary';
+import MongoBinary from '../MongoBinary';
 import MongoBinaryDownload from '../MongoBinaryDownload';
+import resolveConfig, { ResolveConfigVariables } from '../resolveConfig';
+import { assertion } from '../utils';
 
 tmp.setGracefulCleanup();
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
@@ -45,7 +47,8 @@ describe('MongoBinary', () => {
 
   describe('getDownloadPath', () => {
     it('should download binary and keep it in cache', async () => {
-      const version = LATEST_VERSION;
+      const version = resolveConfig(ResolveConfigVariables.VERSION);
+      assertion(typeof version === 'string', new Error('Expected "version" to be an string'));
       const binPath = await MongoBinary.getPath({
         downloadDir: tmpDir.name,
         version,

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
@@ -65,15 +65,8 @@ describe('MongoBinary', () => {
 
       expect(mockGetMongodPath).toHaveBeenCalledTimes(1);
 
-      expect(MongoBinary.getCachePath(version)).toBeDefined();
-      expect(MongoBinary.getCachePath(version)).toEqual(binPath);
-    });
-  });
-
-  describe('getCachePath', () => {
-    it('should get the cache', async () => {
-      MongoBinary.cache.set('3.4.2', '/bin/mongod');
-      expect(MongoBinary.getCachePath('3.4.2')).toEqual('/bin/mongod');
+      expect(MongoBinary.cache.get(version)).toBeDefined();
+      expect(MongoBinary.cache.get(version)).toEqual(binPath);
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
@@ -7,7 +7,7 @@ import resolveConfig, { ENV_CONFIG_PREFIX, ResolveConfigVariables } from '../res
 import { assertion } from '../utils';
 
 tmp.setGracefulCleanup();
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 5; // 5 seconds
 
 const mockGetMongodPath = jest.fn().mockResolvedValue('/temp/path');
 
@@ -34,14 +34,13 @@ describe('MongoBinary', () => {
 
   describe('getPath', () => {
     it('should get system binary from the environment', async () => {
-      const accessSpy = jest.spyOn(fs, 'access');
+      jest.spyOn(fs, 'access');
       process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.SYSTEM_BINARY] =
         '/usr/local/bin/mongod';
       await MongoBinary.getPath();
 
-      expect(accessSpy).toHaveBeenCalledWith('/usr/local/bin/mongod', expect.any(Function));
+      expect(fs.access).toHaveBeenCalledWith('/usr/local/bin/mongod', expect.any(Function));
 
-      accessSpy.mockClear();
       delete process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.SYSTEM_BINARY];
     });
   });
@@ -80,12 +79,10 @@ describe('MongoBinary', () => {
 
   describe('getSystemPath', () => {
     it('should use system binary if option is passed.', async () => {
-      const accessSpy = jest.spyOn(fs, 'access');
+      jest.spyOn(fs, 'access');
       await MongoBinary.getSystemPath('/usr/bin/mongod'); // ignoring return, because this depends on the host system
 
-      expect(accessSpy).toHaveBeenCalledWith('/usr/bin/mongod', expect.any(Function));
-
-      accessSpy.mockClear();
+      expect(fs.access).toHaveBeenCalledWith('/usr/bin/mongod', expect.any(Function));
     });
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import MongoBinary from '../MongoBinary';
 import MongoBinaryDownload from '../MongoBinaryDownload';
-import resolveConfig, { ResolveConfigVariables } from '../resolveConfig';
+import resolveConfig, { ENV_CONFIG_PREFIX, ResolveConfigVariables } from '../resolveConfig';
 import { assertion } from '../utils';
 
 tmp.setGracefulCleanup();
@@ -35,13 +35,14 @@ describe('MongoBinary', () => {
   describe('getPath', () => {
     it('should get system binary from the environment', async () => {
       const accessSpy = jest.spyOn(fs, 'access');
-      process.env.MONGOMS_SYSTEM_BINARY = '/usr/local/bin/mongod';
+      process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.SYSTEM_BINARY] =
+        '/usr/local/bin/mongod';
       await MongoBinary.getPath();
 
       expect(accessSpy).toHaveBeenCalledWith('/usr/local/bin/mongod', expect.any(Function));
 
       accessSpy.mockClear();
-      delete process.env.MONGOMS_SYSTEM_BINARY;
+      delete process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.SYSTEM_BINARY];
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
@@ -1,5 +1,5 @@
 import * as tmp from 'tmp';
-import fs from 'fs';
+import { promises } from 'fs';
 import os from 'os';
 import MongoBinary from '../MongoBinary';
 import MongoBinaryDownload from '../MongoBinaryDownload';
@@ -34,12 +34,12 @@ describe('MongoBinary', () => {
 
   describe('getPath', () => {
     it('should get system binary from the environment', async () => {
-      jest.spyOn(fs, 'access');
+      jest.spyOn(promises, 'access');
       process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.SYSTEM_BINARY] =
         '/usr/local/bin/mongod';
       await MongoBinary.getPath();
 
-      expect(fs.access).toHaveBeenCalledWith('/usr/local/bin/mongod', expect.any(Function));
+      expect(promises.access).toHaveBeenCalledWith('/usr/local/bin/mongod');
 
       delete process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.SYSTEM_BINARY];
     });
@@ -79,10 +79,10 @@ describe('MongoBinary', () => {
 
   describe('getSystemPath', () => {
     it('should use system binary if option is passed.', async () => {
-      jest.spyOn(fs, 'access');
+      jest.spyOn(promises, 'access');
       await MongoBinary.getSystemPath('/usr/bin/mongod'); // ignoring return, because this depends on the host system
 
-      expect(fs.access).toHaveBeenCalledWith('/usr/bin/mongod', expect.any(Function));
+      expect(promises.access).toHaveBeenCalledWith('/usr/bin/mongod');
     });
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
@@ -1,5 +1,5 @@
 import * as tmp from 'tmp';
-import { promises, constants } from 'fs';
+import { promises as fspromises, constants } from 'fs';
 import os from 'os';
 import MongoBinary from '../MongoBinary';
 import MongoBinaryDownload from '../MongoBinaryDownload';
@@ -34,12 +34,12 @@ describe('MongoBinary', () => {
 
   describe('getPath', () => {
     it('should get system binary from the environment', async () => {
-      jest.spyOn(promises, 'access');
+      jest.spyOn(fspromises, 'access');
       process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.SYSTEM_BINARY] =
         '/usr/local/bin/mongod';
       await MongoBinary.getPath();
 
-      expect(promises.access).toHaveBeenCalledWith('/usr/local/bin/mongod', constants.X_OK);
+      expect(fspromises.access).toHaveBeenCalledWith('/usr/local/bin/mongod', constants.X_OK);
 
       delete process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.SYSTEM_BINARY];
     });
@@ -72,10 +72,10 @@ describe('MongoBinary', () => {
 
   describe('getSystemPath', () => {
     it('should use system binary if option is passed.', async () => {
-      jest.spyOn(promises, 'access');
+      jest.spyOn(fspromises, 'access');
       await MongoBinary.getSystemPath('/usr/bin/mongod'); // ignoring return, because this depends on the host system
 
-      expect(promises.access).toHaveBeenCalledWith('/usr/bin/mongod', constants.X_OK);
+      expect(fspromises.access).toHaveBeenCalledWith('/usr/bin/mongod', constants.X_OK);
     });
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
@@ -1,5 +1,5 @@
 import * as tmp from 'tmp';
-import { promises } from 'fs';
+import { promises, constants } from 'fs';
 import os from 'os';
 import MongoBinary from '../MongoBinary';
 import MongoBinaryDownload from '../MongoBinaryDownload';
@@ -39,7 +39,7 @@ describe('MongoBinary', () => {
         '/usr/local/bin/mongod';
       await MongoBinary.getPath();
 
-      expect(promises.access).toHaveBeenCalledWith('/usr/local/bin/mongod');
+      expect(promises.access).toHaveBeenCalledWith('/usr/local/bin/mongod', constants.X_OK);
 
       delete process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.SYSTEM_BINARY];
     });
@@ -75,7 +75,7 @@ describe('MongoBinary', () => {
       jest.spyOn(promises, 'access');
       await MongoBinary.getSystemPath('/usr/bin/mongod'); // ignoring return, because this depends on the host system
 
-      expect(promises.access).toHaveBeenCalledWith('/usr/bin/mongod');
+      expect(promises.access).toHaveBeenCalledWith('/usr/bin/mongod', constants.X_OK);
     });
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -94,14 +94,15 @@ describe('MongoBinaryDownload', () => {
     process.env['npm_config_strict_ssl'] = 'true';
 
     const du = new MongoBinaryDownload({});
-    du.httpDownload = jest.fn();
-    du.locationExists = jest.fn().mockReturnValue(false);
+    jest.spyOn(du, 'httpDownload').mockResolvedValue('/tmp/someFile.tgz');
+    jest.spyOn(du, 'locationExists').mockResolvedValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);
-    const callArg1 = (du.httpDownload as jest.Mock).mock.calls[0][0];
-    expect(callArg1.rejectUnauthorized).toBeDefined();
-    expect(callArg1.rejectUnauthorized).toBe(true);
+    const callArg1 = ((du.httpDownload as jest.Mock).mock.calls[0] as Parameters<
+      MongoBinaryDownload['httpDownload']
+    >)[0];
+    expect(callArg1.rejectUnauthorized).toEqual(true);
   });
 
   it('makeMD5check returns true if md5 of downloaded mongoDBArchive is the same as in the reference result', () => {

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -2,7 +2,7 @@ import { promises } from 'fs';
 import md5file from 'md5-file';
 import MongoBinaryDownload from '../MongoBinaryDownload';
 import { ENV_CONFIG_PREFIX, ResolveConfigVariables } from '../resolveConfig';
-import { assertion, isNullOrUndefined } from '../utils';
+import * as utils from '../utils';
 
 jest.mock('md5-file');
 
@@ -32,7 +32,7 @@ describe('MongoBinaryDownload', () => {
 
     const du = new MongoBinaryDownload({});
     jest.spyOn(du, 'httpDownload').mockResolvedValue('/tmp/someFile.tgz');
-    jest.spyOn(du, 'locationExists').mockResolvedValue(false);
+    jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);
@@ -45,7 +45,7 @@ describe('MongoBinaryDownload', () => {
   it('should skip download if binary tar exists', async () => {
     const du = new MongoBinaryDownload({});
     jest.spyOn(du, 'httpDownload').mockResolvedValue('/tmp/someFile.tgz');
-    jest.spyOn(du, 'locationExists').mockResolvedValue(true);
+    jest.spyOn(utils, 'pathExists').mockResolvedValue(true);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
 
@@ -57,15 +57,15 @@ describe('MongoBinaryDownload', () => {
 
     const du = new MongoBinaryDownload({});
     jest.spyOn(du, 'httpDownload').mockResolvedValue('/tmp/someFile.tgz');
-    jest.spyOn(du, 'locationExists').mockResolvedValue(false);
+    jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);
     const callArg1 = ((du.httpDownload as jest.Mock).mock.calls[0] as Parameters<
       MongoBinaryDownload['httpDownload']
     >)[0];
-    assertion(
-      !isNullOrUndefined(callArg1.agent),
+    utils.assertion(
+      !utils.isNullOrUndefined(callArg1.agent),
       new Error('Expected "callArg1.agent" to be defined')
     );
     // @ts-expect-error because "proxy" if soft-private
@@ -78,7 +78,7 @@ describe('MongoBinaryDownload', () => {
 
     const du = new MongoBinaryDownload({});
     jest.spyOn(du, 'httpDownload').mockResolvedValue('/tmp/someFile.tgz');
-    jest.spyOn(du, 'locationExists').mockResolvedValue(false);
+    jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);
@@ -94,7 +94,7 @@ describe('MongoBinaryDownload', () => {
 
     const du = new MongoBinaryDownload({});
     jest.spyOn(du, 'httpDownload').mockResolvedValue('/tmp/someFile.tgz');
-    jest.spyOn(du, 'locationExists').mockResolvedValue(false);
+    jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -1,4 +1,4 @@
-import { promises } from 'fs';
+import { promises as fspromises } from 'fs';
 import md5file from 'md5-file';
 import MongoBinaryDownload from '../MongoBinaryDownload';
 import { ENV_CONFIG_PREFIX, ResolveConfigVariables } from '../resolveConfig';
@@ -109,7 +109,7 @@ describe('MongoBinaryDownload', () => {
     const mongoDBArchivePath = '/some/path';
     const fileWithReferenceMd5 = '/another/path';
 
-    jest.spyOn(promises, 'readFile').mockResolvedValueOnce(`${someMd5} fileName`);
+    jest.spyOn(fspromises, 'readFile').mockResolvedValueOnce(`${someMd5} fileName`);
     jest.spyOn(md5file, 'sync').mockImplementationOnce(() => someMd5);
 
     const du = new MongoBinaryDownload({});
@@ -120,12 +120,12 @@ describe('MongoBinaryDownload', () => {
 
     expect(res).toBe(true);
     expect(du.download).toBeCalledWith(urlToMongoDBArchivePath);
-    expect(promises.readFile).toBeCalledWith(fileWithReferenceMd5);
+    expect(fspromises.readFile).toBeCalledWith(fileWithReferenceMd5);
     expect(md5file.sync).toBeCalledWith(mongoDBArchivePath);
   });
 
   it('makeMD5check throws an error if md5 of downloaded mongoDBArchive is NOT the same as in the reference result', async () => {
-    jest.spyOn(promises, 'readFile').mockResolvedValueOnce(`someMD5 fileName`);
+    jest.spyOn(fspromises, 'readFile').mockResolvedValueOnce(`someMD5 fileName`);
     jest.spyOn(md5file, 'sync').mockImplementationOnce(() => 'anotherMD5');
 
     const du = new MongoBinaryDownload({});
@@ -137,7 +137,7 @@ describe('MongoBinaryDownload', () => {
   });
 
   it('false value of checkMD5 attribute disables makeMD5check validation', async () => {
-    jest.spyOn(promises, 'readFile').mockResolvedValueOnce(`someMD5 fileName`);
+    jest.spyOn(fspromises, 'readFile').mockResolvedValueOnce(`someMD5 fileName`);
     jest.spyOn(md5file, 'sync').mockImplementationOnce(() => 'anotherMD5');
 
     const du = new MongoBinaryDownload({});

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -16,8 +16,7 @@ describe('MongoBinaryDownload', () => {
     expect(new MongoBinaryDownload({ checkMD5: false }).checkMD5).toBe(false);
   });
 
-  it(`if checkMD5 input parameter is missing, then it checks
-MONGOMS_MD5_CHECK environment variable`, () => {
+  it('if checkMD5 input parameter is missing, then it checks "MONGOMS_MD5_CHECK" environment variable', () => {
     expect(new MongoBinaryDownload({}).checkMD5).toBe(false);
     process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.MD5_CHECK] = '1';
     expect(new MongoBinaryDownload({}).checkMD5).toBe(true);
@@ -98,8 +97,7 @@ MONGOMS_MD5_CHECK environment variable`, () => {
     expect(callArg1.rejectUnauthorized).toBe(true);
   });
 
-  it(`makeMD5check returns true if md5 of downloaded mongoDBArchive is
-the same as in the reference result`, () => {
+  it('makeMD5check returns true if md5 of downloaded mongoDBArchive is the same as in the reference result', () => {
     const someMd5 = 'md5';
     (fs.readFileSync as jest.Mock).mockImplementationOnce(() => `${someMd5} fileName`);
     (md5file.sync as jest.Mock).mockImplementationOnce(() => someMd5);
@@ -118,8 +116,7 @@ the same as in the reference result`, () => {
     });
   });
 
-  it(`makeMD5check throws an error if md5 of downloaded mongoDBArchive is NOT
-  the same as in the reference result`, () => {
+  it('makeMD5check throws an error if md5 of downloaded mongoDBArchive is NOT the same as in the reference result', () => {
     (fs.readFileSync as jest.Mock).mockImplementationOnce(() => 'someMd5 fileName');
     (md5file.sync as jest.Mock).mockImplementationOnce(() => 'anotherMd5');
     const du = new MongoBinaryDownload({});

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -32,12 +32,14 @@ MONGOMS_MD5_CHECK environment variable`, () => {
     process.env['http_proxy'] = '';
 
     const du = new MongoBinaryDownload({});
-    du.httpDownload = jest.fn();
-    du.locationExists = jest.fn().mockReturnValue(false);
+    jest.spyOn(du, 'httpDownload').mockResolvedValue('/tmp/someFile.tgz');
+    jest.spyOn(du, 'locationExists').mockResolvedValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);
-    const callArg1 = (du.httpDownload as jest.Mock).mock.calls[0][0];
+    const callArg1 = ((du.httpDownload as jest.Mock).mock.calls[0] as Parameters<
+      MongoBinaryDownload['httpDownload']
+    >)[0];
     expect(callArg1.agent).toBeUndefined();
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -138,12 +138,12 @@ describe('MongoBinaryDownload', () => {
   });
 
   it('false value of checkMD5 attribute disables makeMD5check validation', async () => {
-    expect.assertions(1);
-    (fs.readFileSync as jest.Mock).mockImplementationOnce(() => 'someMd5 fileName');
-    (md5file.sync as jest.Mock).mockImplementationOnce(() => 'anotherMd5');
+    jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => `someMD5 fileName`);
+    jest.spyOn(md5file, 'sync').mockImplementationOnce(() => 'anotherMD5');
+
     const du = new MongoBinaryDownload({});
     du.checkMD5 = false;
     const result = await du.makeMD5check('', '');
-    expect(result).toBe(undefined);
+    expect(result).toEqual(undefined);
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -78,14 +78,15 @@ describe('MongoBinaryDownload', () => {
     process.env['npm_config_strict_ssl'] = '';
 
     const du = new MongoBinaryDownload({});
-    du.httpDownload = jest.fn();
-    du.locationExists = jest.fn().mockReturnValue(false);
+    jest.spyOn(du, 'httpDownload').mockResolvedValue('/tmp/someFile.tgz');
+    jest.spyOn(du, 'locationExists').mockResolvedValue(false);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
     expect(du.httpDownload).toHaveBeenCalledTimes(1);
-    const callArg1 = (du.httpDownload as jest.Mock).mock.calls[0][0];
-    expect(callArg1.rejectUnauthorized).toBeDefined();
-    expect(callArg1.rejectUnauthorized).toBe(false);
+    const callArg1 = ((du.httpDownload as jest.Mock).mock.calls[0] as Parameters<
+      MongoBinaryDownload['httpDownload']
+    >)[0];
+    expect(callArg1.rejectUnauthorized).toEqual(false);
   });
 
   it('should reject unauthorized when npm strict-ssl config is true', async () => {

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -44,8 +44,8 @@ describe('MongoBinaryDownload', () => {
 
   it('should skip download if binary tar exists', async () => {
     const du = new MongoBinaryDownload({});
-    du.httpDownload = jest.fn();
-    du.locationExists = jest.fn().mockReturnValue(true);
+    jest.spyOn(du, 'httpDownload').mockResolvedValue('/tmp/someFile.tgz');
+    jest.spyOn(du, 'locationExists').mockResolvedValue(true);
 
     await du.download('https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.3.tgz');
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -1,10 +1,9 @@
-import fs from 'fs';
+import { promises } from 'fs';
 import md5file from 'md5-file';
 import MongoBinaryDownload from '../MongoBinaryDownload';
 import { ENV_CONFIG_PREFIX, ResolveConfigVariables } from '../resolveConfig';
 import { assertion, isNullOrUndefined } from '../utils';
 
-jest.mock('fs');
 jest.mock('md5-file');
 
 describe('MongoBinaryDownload', () => {
@@ -110,7 +109,7 @@ describe('MongoBinaryDownload', () => {
     const mongoDBArchivePath = '/some/path';
     const fileWithReferenceMd5 = '/another/path';
 
-    jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => `${someMd5} fileName`);
+    jest.spyOn(promises, 'readFile').mockResolvedValueOnce(`${someMd5} fileName`);
     jest.spyOn(md5file, 'sync').mockImplementationOnce(() => someMd5);
 
     const du = new MongoBinaryDownload({});
@@ -121,12 +120,12 @@ describe('MongoBinaryDownload', () => {
 
     expect(res).toBe(true);
     expect(du.download).toBeCalledWith(urlToMongoDBArchivePath);
-    expect(fs.readFileSync).toBeCalledWith(fileWithReferenceMd5);
+    expect(promises.readFile).toBeCalledWith(fileWithReferenceMd5);
     expect(md5file.sync).toBeCalledWith(mongoDBArchivePath);
   });
 
   it('makeMD5check throws an error if md5 of downloaded mongoDBArchive is NOT the same as in the reference result', async () => {
-    jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => `someMD5 fileName`);
+    jest.spyOn(promises, 'readFile').mockResolvedValueOnce(`someMD5 fileName`);
     jest.spyOn(md5file, 'sync').mockImplementationOnce(() => 'anotherMD5');
 
     const du = new MongoBinaryDownload({});
@@ -138,7 +137,7 @@ describe('MongoBinaryDownload', () => {
   });
 
   it('false value of checkMD5 attribute disables makeMD5check validation', async () => {
-    jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => `someMD5 fileName`);
+    jest.spyOn(promises, 'readFile').mockResolvedValueOnce(`someMD5 fileName`);
     jest.spyOn(md5file, 'sync').mockImplementationOnce(() => 'anotherMD5');
 
     const du = new MongoBinaryDownload({});

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -1,13 +1,14 @@
 import fs from 'fs';
 import md5file from 'md5-file';
 import MongoBinaryDownload from '../MongoBinaryDownload';
+import { ENV_CONFIG_PREFIX, ResolveConfigVariables } from '../resolveConfig';
 
 jest.mock('fs');
 jest.mock('md5-file');
 
 describe('MongoBinaryDownload', () => {
   afterEach(() => {
-    delete process.env.MONGOMS_SKIP_MD5_CHECK;
+    delete process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.MD5_CHECK];
   });
 
   it('checkMD5 attribute can be set via constructor parameter', () => {
@@ -18,7 +19,7 @@ describe('MongoBinaryDownload', () => {
   it(`if checkMD5 input parameter is missing, then it checks
 MONGOMS_MD5_CHECK environment variable`, () => {
     expect(new MongoBinaryDownload({}).checkMD5).toBe(false);
-    process.env.MONGOMS_MD5_CHECK = '1';
+    process.env[ENV_CONFIG_PREFIX + ResolveConfigVariables.MD5_CHECK] = '1';
     expect(new MongoBinaryDownload({}).checkMD5).toBe(true);
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownload.test.ts
@@ -125,13 +125,14 @@ describe('MongoBinaryDownload', () => {
     expect(md5file.sync).toBeCalledWith(mongoDBArchivePath);
   });
 
-  it('makeMD5check throws an error if md5 of downloaded mongoDBArchive is NOT the same as in the reference result', () => {
-    (fs.readFileSync as jest.Mock).mockImplementationOnce(() => 'someMd5 fileName');
-    (md5file.sync as jest.Mock).mockImplementationOnce(() => 'anotherMd5');
+  it('makeMD5check throws an error if md5 of downloaded mongoDBArchive is NOT the same as in the reference result', async () => {
+    jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => `someMD5 fileName`);
+    jest.spyOn(md5file, 'sync').mockImplementationOnce(() => 'anotherMD5');
+
     const du = new MongoBinaryDownload({});
     du.checkMD5 = true;
-    du.download = jest.fn(() => Promise.resolve(''));
-    expect(du.makeMD5check('', '')).rejects.toMatchInlineSnapshot(
+    jest.spyOn(du, 'download').mockResolvedValue('');
+    await expect(du.makeMD5check('', '')).rejects.toMatchInlineSnapshot(
       `[Error: MongoBinaryDownload: md5 check failed]`
     );
   });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -1,5 +1,5 @@
 import MongoBinaryDownloadUrl from '../MongoBinaryDownloadUrl';
-import { defaultValues, setDefaultValue } from '../resolveConfig';
+import { defaultValues, ResolveConfigVariables, setDefaultValue } from '../resolveConfig';
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -164,14 +164,14 @@ describe('MongoBinaryDownloadUrl', () => {
 
     it('should allow overwrite with "ARCHIVE_NAME"', async () => {
       const archiveName = 'mongodb-linux-x86_64-4.0.0.tgz';
-      setDefaultValue('ARCHIVE_NAME', archiveName);
+      setDefaultValue(ResolveConfigVariables.ARCHIVE_NAME, archiveName);
       const du = new MongoBinaryDownloadUrl({
         platform: 'linux',
         arch: 'x64',
         version: '3.6.3',
       });
       expect(await du.getDownloadUrl()).toBe(`https://fastdl.mongodb.org/linux/${archiveName}`);
-      defaultValues.delete('ARCHIVE_NAME');
+      defaultValues.delete(ResolveConfigVariables.ARCHIVE_NAME);
     });
 
     it('should throw an error if platform is unkown (getArchiveName)', async () => {

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance.test.ts
@@ -204,6 +204,7 @@ describe('MongodbInstance', () => {
       events = new Map();
       jest.spyOn(mongod, 'emit').mockImplementation((event: string, arg1: string) => {
         events.set(event, arg1);
+
         return true;
       });
     });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoInstance.test.ts
@@ -160,20 +160,11 @@ describe('MongodbInstance', () => {
     expect(pid).toBeGreaterThan(0);
     expect(killerPid).toBeGreaterThan(0);
 
-    function isPidRunning(p: number): boolean {
-      try {
-        process.kill(p, 0);
-        return true;
-      } catch (e) {
-        return e.code === 'EPERM';
-      }
-    }
-
-    expect(isPidRunning(pid)).toBeTruthy();
-    expect(isPidRunning(killerPid)).toBeTruthy();
+    expect(dbUtil.isAlive(pid)).toBeTruthy();
+    expect(dbUtil.isAlive(killerPid)).toBeTruthy();
     await mongod.kill();
-    expect(isPidRunning(pid)).toBeFalsy();
-    expect(isPidRunning(killerPid)).toBeFalsy();
+    expect(dbUtil.isAlive(pid)).toBeFalsy();
+    expect(dbUtil.isAlive(killerPid)).toBeFalsy();
   });
 
   it('should work with mongodb 4.0.3', async () => {

--- a/packages/mongodb-memory-server-core/src/util/__tests__/resolveConfig.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/resolveConfig.test.ts
@@ -1,11 +1,8 @@
-import fs from 'fs';
+import { promises } from 'fs';
 import * as tmp from 'tmp';
-import { promisify } from 'util';
 import resolveConfig, { findPackageJson, ResolveConfigVariables } from '../resolveConfig';
 
 tmp.setGracefulCleanup();
-const mkdirAsync = promisify(fs.mkdir);
-const writeFileAsync = promisify(fs.writeFile);
 
 const outerPackageJson = {
   config: {
@@ -38,16 +35,16 @@ describe('resolveConfig', () => {
       tmpObj = tmp.dirSync({ unsafeCleanup: true });
       const tmpName = tmpObj.name;
 
-      await mkdirAsync(`${tmpName}/project`);
-      await mkdirAsync(`${tmpName}/project/subproject`);
+      await promises.mkdir(`${tmpName}/project`);
+      await promises.mkdir(`${tmpName}/project/subproject`);
 
       // prettier-ignore
       await Promise.all([
-        writeFileAsync(
+        promises.writeFile(
           `${tmpName}/project/package.json`,
           JSON.stringify(outerPackageJson)
         ),
-        writeFileAsync(
+        promises.writeFile(
           `${tmpName}/project/subproject/package.json`,
           JSON.stringify(innerPackageJson)
         ),

--- a/packages/mongodb-memory-server-core/src/util/__tests__/resolveConfig.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/resolveConfig.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import * as tmp from 'tmp';
 import { promisify } from 'util';
-import resolveConfig, { findPackageJson } from '../resolveConfig';
+import resolveConfig, { findPackageJson, ResolveConfigVariables } from '../resolveConfig';
 
 tmp.setGracefulCleanup();
 const mkdirAsync = promisify(fs.mkdir);
@@ -62,21 +62,21 @@ describe('resolveConfig', () => {
     test('in project', () => {
       process.chdir(`${tmpObj.name}/project`);
       findPackageJson();
-      const got = resolveConfig('VERSION');
+      const got = resolveConfig(ResolveConfigVariables.VERSION);
       expect(got).toBe('3.0.0');
     });
 
     test('in subproject', () => {
       process.chdir(`${tmpObj.name}/project/subproject`);
       findPackageJson();
-      const got = resolveConfig('VERSION');
+      const got = resolveConfig(ResolveConfigVariables.VERSION);
       expect(got).toBe('4.0.0');
     });
 
     test('with explicit directory in reInitializePackageJson', () => {
       process.chdir(`${tmpObj.name}/project`);
       findPackageJson(`${tmpObj.name}/project/subproject`);
-      const got = resolveConfig('VERSION');
+      const got = resolveConfig(ResolveConfigVariables.VERSION);
       expect(got).toBe('4.0.0');
     });
   });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/resolveConfig.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/resolveConfig.test.ts
@@ -1,4 +1,4 @@
-import { promises } from 'fs';
+import { promises as fspromises } from 'fs';
 import * as tmp from 'tmp';
 import resolveConfig, { findPackageJson, ResolveConfigVariables } from '../resolveConfig';
 
@@ -35,16 +35,16 @@ describe('resolveConfig', () => {
       tmpObj = tmp.dirSync({ unsafeCleanup: true });
       const tmpName = tmpObj.name;
 
-      await promises.mkdir(`${tmpName}/project`);
-      await promises.mkdir(`${tmpName}/project/subproject`);
+      await fspromises.mkdir(`${tmpName}/project`);
+      await fspromises.mkdir(`${tmpName}/project/subproject`);
 
       // prettier-ignore
       await Promise.all([
-        promises.writeFile(
+        fspromises.writeFile(
           `${tmpName}/project/package.json`,
           JSON.stringify(outerPackageJson)
         ),
-        promises.writeFile(
+        fspromises.writeFile(
           `${tmpName}/project/subproject/package.json`,
           JSON.stringify(innerPackageJson)
         ),

--- a/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
@@ -28,4 +28,14 @@ describe('utils', () => {
       await expect(utils.pathExists('/some/path')).resolves.toEqual(false);
     });
   });
+
+  describe('statPath', () => {
+    it('should throw an error if code is not "ENOENT"', async () => {
+      const retError = new Error();
+      // @ts-expect-error because there is no FSError, or an error with an "code" property - but still being used
+      retError.code = 'EPERM';
+      jest.spyOn(promises, 'stat').mockRejectedValueOnce(retError);
+      await expect(utils.statPath('/some/path')).rejects.toThrowError(retError);
+    });
+  });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { Stats, promises } from 'fs';
+import { Stats, promises as fspromises } from 'fs';
 import * as utils from '../utils';
 
 describe('utils', () => {
@@ -16,7 +16,7 @@ describe('utils', () => {
 
   describe('pathExists', () => {
     it('should return true if there are stats', async () => {
-      jest.spyOn(promises, 'stat').mockResolvedValueOnce(new Stats());
+      jest.spyOn(fspromises, 'stat').mockResolvedValueOnce(new Stats());
       await expect(utils.pathExists('/some/path')).resolves.toEqual(true);
     });
 
@@ -24,7 +24,7 @@ describe('utils', () => {
       const retError = new Error();
       // @ts-expect-error because there is no FSError, or an error with an "code" property - but still being used
       retError.code = 'ENOENT';
-      jest.spyOn(promises, 'stat').mockRejectedValueOnce(retError);
+      jest.spyOn(fspromises, 'stat').mockRejectedValueOnce(retError);
       await expect(utils.pathExists('/some/path')).resolves.toEqual(false);
     });
   });
@@ -34,7 +34,7 @@ describe('utils', () => {
       const retError = new Error();
       // @ts-expect-error because there is no FSError, or an error with an "code" property - but still being used
       retError.code = 'EPERM';
-      jest.spyOn(promises, 'stat').mockRejectedValueOnce(retError);
+      jest.spyOn(fspromises, 'stat').mockRejectedValueOnce(retError);
       await expect(utils.statPath('/some/path')).rejects.toThrowError(retError);
     });
   });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
@@ -1,15 +1,31 @@
-import { uriTemplate } from '../utils';
+import { Stats, promises } from 'fs';
+import * as utils from '../utils';
 
 describe('utils', () => {
   describe('uriTemplate', () => {
     it('should not add "?" without query options', () => {
-      expect(uriTemplate('0.0.0.0', 1001, 'somedb')).toEqual('mongodb://0.0.0.0:1001/somedb');
+      expect(utils.uriTemplate('0.0.0.0', 1001, 'somedb')).toEqual('mongodb://0.0.0.0:1001/somedb');
     });
 
     it('should add "?" with query options', () => {
-      expect(uriTemplate('0.0.0.0', 1001, 'somedb', ['option1=1', 'option2=2'])).toEqual(
+      expect(utils.uriTemplate('0.0.0.0', 1001, 'somedb', ['option1=1', 'option2=2'])).toEqual(
         'mongodb://0.0.0.0:1001/somedb?option1=1&option2=2'
       );
+    });
+  });
+
+  describe('pathExists', () => {
+    it('should return true if there are stats', async () => {
+      jest.spyOn(promises, 'stat').mockResolvedValueOnce(new Stats());
+      await expect(utils.pathExists('/some/path')).resolves.toEqual(true);
+    });
+
+    it('should return false if there are no stats', async () => {
+      const retError = new Error();
+      // @ts-expect-error because there is no FSError, or an error with an "code" property - but still being used
+      retError.code = 'ENOENT';
+      jest.spyOn(promises, 'stat').mockRejectedValueOnce(retError);
+      await expect(utils.pathExists('/some/path')).resolves.toEqual(false);
     });
   });
 });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
@@ -46,7 +46,7 @@ describe('utils', () => {
         utils.assertion(false);
         fail('Expected Assertion to Throw');
       } catch (err) {
-        expect(err.message).toEqual('Assert failed - no custom error [E019]');
+        expect(err.message).toEqual('Assert failed - no custom error');
       }
     });
   });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
@@ -38,4 +38,16 @@ describe('utils', () => {
       await expect(utils.statPath('/some/path')).rejects.toThrowError(retError);
     });
   });
+
+  describe('assertion', () => {
+    it('should throw default error if none provided', () => {
+      expect.assertions(1);
+      try {
+        utils.assertion(false);
+        fail('Expected Assertion to Throw');
+      } catch (err) {
+        expect(err.message).toEqual('Assert failed - no custom error [E019]');
+      }
+    });
+  });
 });

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -3,7 +3,7 @@ import { platform } from 'os';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { join } from 'path';
-import resolveConfig, { ResolveConfigVariables } from '../resolveConfig';
+import resolveConfig, { envToBool, ResolveConfigVariables } from '../resolveConfig';
 import debug from 'debug';
 import { isNullOrUndefined } from '../utils';
 
@@ -68,19 +68,19 @@ async function getLinuxInfomation(): Promise<LinuxOS> {
   // (if not 2) 3. try read dir /etc and filter any file "-release" and try to parse the first file found
 
   // Force "lsb_release" to be used
-  if (!isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_LSB_RELEASE))) {
+  if (envToBool(resolveConfig(ResolveConfigVariables.USE_LINUX_LSB_RELEASE))) {
     log('Forced LSB-Release file!');
 
     return (await tryLSBRelease()) as LinuxOS;
   }
   // Force /etc/os-release to be used
-  if (!isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_OS_RELEASE))) {
+  if (envToBool(resolveConfig(ResolveConfigVariables.USE_LINUX_OS_RELEASE))) {
     log('Forced OS-Release file!');
 
     return (await tryOSRelease()) as LinuxOS;
   }
   // Force the first /etc/*-release file to be used
-  if (!isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_ANY_RELEASE))) {
+  if (envToBool(resolveConfig(ResolveConfigVariables.USE_LINUX_ANY_RELEASE))) {
     log('Forced First *-Release file!');
 
     return (await tryFirstReleaseFile()) as LinuxOS;
@@ -153,7 +153,7 @@ async function tryOSRelease(): Promise<LinuxOS | undefined> {
     // and just return
     if (
       (err?.code === 'ENOENT' ||
-        !isNullOrUndefined(resolveConfig(ResolveConfigVariables.SKIP_OS_RELEASE))) &&
+        envToBool(resolveConfig(ResolveConfigVariables.SKIP_OS_RELEASE))) &&
       isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_OS_RELEASE))
     ) {
       return;

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -4,7 +4,7 @@ import { platform } from 'os';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { join } from 'path';
-import resolveConfig from '../resolveConfig';
+import resolveConfig, { ResolveConfigVariables } from '../resolveConfig';
 import debug from 'debug';
 import { isNullOrUndefined } from '../utils';
 
@@ -69,17 +69,17 @@ async function getLinuxInfomation(): Promise<LinuxOS> {
   // (if not 2) 3. try read dir /etc and filter any file "-release" and try to parse the first file found
 
   // Force "lsb_release" to be used
-  if (!isNullOrUndefined(resolveConfig('USE_LINUX_LSB_RELEASE'))) {
+  if (!isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_LSB_RELEASE))) {
     log('Forced LSB-Release file!');
     return (await tryLSBRelease()) as LinuxOS;
   }
   // Force /etc/os-release to be used
-  if (!isNullOrUndefined(resolveConfig('USE_LINUX_OS_RELEASE'))) {
+  if (!isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_OS_RELEASE))) {
     log('Forced OS-Release file!');
     return (await tryOSRelease()) as LinuxOS;
   }
   // Force the first /etc/*-release file to be used
-  if (!isNullOrUndefined(resolveConfig('USE_LINUX_ANYFILE_RELEASE'))) {
+  if (!isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_ANY_RELEASE))) {
     log('Forced First *-Release file!');
     return (await tryFirstReleaseFile()) as LinuxOS;
   }
@@ -124,7 +124,7 @@ async function tryLSBRelease(): Promise<LinuxOS | undefined> {
     return parseLSB(lsb.stdout);
   } catch (err) {
     // check if "USE_LINUX_LSB_RELEASE" is unset, when yes - just return to start the next try
-    if (isNullOrUndefined(resolveConfig('USE_LINUX_LSB_RELEASE'))) {
+    if (isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_LSB_RELEASE))) {
       return;
     }
 
@@ -146,8 +146,9 @@ async function tryOSRelease(): Promise<LinuxOS | undefined> {
     // AND "USE_LINUX_OS_RELEASE" is unset
     // and just return
     if (
-      (err?.code === 'ENOENT' || !isNullOrUndefined(resolveConfig('SKIP_OS_RELEASE'))) &&
-      isNullOrUndefined(resolveConfig('USE_LINUX_OS_RELEASE'))
+      (err?.code === 'ENOENT' ||
+        !isNullOrUndefined(resolveConfig(ResolveConfigVariables.SKIP_OS_RELEASE))) &&
+      isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_OS_RELEASE))
     ) {
       return;
     }
@@ -179,7 +180,10 @@ async function tryFirstReleaseFile(): Promise<LinuxOS | undefined> {
     // check if the error is an "ENOENT" OR "SKIP_RELEASE" is set
     // AND "USE_LINUX_RELEASE" is unset
     // and just return
-    if (err?.code === 'ENOENT' && isNullOrUndefined(resolveConfig('USE_LINUX_ANYFILE_RELEASE'))) {
+    if (
+      err?.code === 'ENOENT' &&
+      isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_ANY_RELEASE))
+    ) {
       return;
     }
 

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -1,4 +1,4 @@
-import { promises } from 'fs';
+import { promises as fspromises } from 'fs';
 import { platform } from 'os';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -144,7 +144,7 @@ async function tryLSBRelease(): Promise<LinuxOS | undefined> {
  */
 async function tryOSRelease(): Promise<LinuxOS | undefined> {
   try {
-    const os = await promises.readFile('/etc/os-release');
+    const os = await fspromises.readFile('/etc/os-release');
 
     return parseOS(os.toString());
   } catch (err) {
@@ -169,7 +169,7 @@ async function tryOSRelease(): Promise<LinuxOS | undefined> {
  */
 async function tryFirstReleaseFile(): Promise<LinuxOS | undefined> {
   try {
-    const file = (await promises.readdir('/etc')).filter(
+    const file = (await fspromises.readdir('/etc')).filter(
       (v) =>
         // match if file ends with "-release"
         v.match(/.*-release$/im) &&
@@ -181,7 +181,7 @@ async function tryFirstReleaseFile(): Promise<LinuxOS | undefined> {
       throw new Error('No release file found!');
     }
 
-    const os = await promises.readFile(join('/etc/', file));
+    const os = await fspromises.readFile(join('/etc/', file));
 
     return parseOS(os.toString());
   } catch (err) {

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir } from 'fs';
+import { promises } from 'fs';
 import { platform } from 'os';
 
 import { exec } from 'child_process';
@@ -138,7 +138,7 @@ async function tryLSBRelease(): Promise<LinuxOS | undefined> {
  */
 async function tryOSRelease(): Promise<LinuxOS | undefined> {
   try {
-    const os = await promisify(readFile)('/etc/os-release');
+    const os = await promises.readFile('/etc/os-release');
 
     return parseOS(os.toString());
   } catch (err) {
@@ -163,7 +163,7 @@ async function tryOSRelease(): Promise<LinuxOS | undefined> {
  */
 async function tryFirstReleaseFile(): Promise<LinuxOS | undefined> {
   try {
-    const file = (await promisify(readdir)('/etc')).filter(
+    const file = (await promises.readdir('/etc')).filter(
       (v) =>
         // match if file ends with "-release"
         v.match(/.*-release$/im) &&
@@ -173,7 +173,7 @@ async function tryFirstReleaseFile(): Promise<LinuxOS | undefined> {
     if (isNullOrUndefined(file) || file.length <= 0) {
       throw new Error('No release file found!');
     }
-    const os = await promisify(readFile)(join('/etc/', file));
+    const os = await promises.readFile(join('/etc/', file));
 
     return parseOS(os.toString());
   } catch (err) {

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -92,18 +92,21 @@ async function getLinuxInfomation(): Promise<LinuxOS> {
 
   log('Trying LSB-Release');
   const lsbOut = await tryLSBRelease();
+
   if (!isNullOrUndefined(lsbOut)) {
     return lsbOut;
   }
 
   log('Trying OS-Release');
   const osOut = await tryOSRelease();
+
   if (!isNullOrUndefined(osOut)) {
     return osOut;
   }
 
   log('Trying First *-Release file');
   const releaseOut = await tryFirstReleaseFile();
+
   if (!isNullOrUndefined(releaseOut)) {
     return releaseOut;
   }
@@ -174,9 +177,11 @@ async function tryFirstReleaseFile(): Promise<LinuxOS | undefined> {
         // check if the file does NOT contain "lsb"
         !v.match(/lsb/im)
     )[0];
+
     if (isNullOrUndefined(file) || file.length <= 0) {
       throw new Error('No release file found!');
     }
+
     const os = await promises.readFile(join('/etc/', file));
 
     return parseOS(os.toString());

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -71,16 +71,19 @@ async function getLinuxInfomation(): Promise<LinuxOS> {
   // Force "lsb_release" to be used
   if (!isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_LSB_RELEASE))) {
     log('Forced LSB-Release file!');
+
     return (await tryLSBRelease()) as LinuxOS;
   }
   // Force /etc/os-release to be used
   if (!isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_OS_RELEASE))) {
     log('Forced OS-Release file!');
+
     return (await tryOSRelease()) as LinuxOS;
   }
   // Force the first /etc/*-release file to be used
   if (!isNullOrUndefined(resolveConfig(ResolveConfigVariables.USE_LINUX_ANY_RELEASE))) {
     log('Forced First *-Release file!');
+
     return (await tryFirstReleaseFile()) as LinuxOS;
   }
 
@@ -106,6 +109,7 @@ async function getLinuxInfomation(): Promise<LinuxOS> {
   }
 
   log('Couldnt find an release file');
+
   // if none has worked, return unkown
   return {
     os: 'linux',

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -1,6 +1,5 @@
 import { promises } from 'fs';
 import { platform } from 'os';
-
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { join } from 'path';

--- a/packages/mongodb-memory-server-core/src/util/postinstallHelper.ts
+++ b/packages/mongodb-memory-server-core/src/util/postinstallHelper.ts
@@ -8,12 +8,15 @@ import {
   envToBool,
   reInitializePackageJson,
   resolveConfig,
+  ResolveConfigVariables,
   setDefaultValue,
 } from './resolveConfig';
 
 reInitializePackageJson(process.env.INIT_CWD);
 
-const envDisablePostinstall: string | undefined = resolveConfig('DISABLE_POSTINSTALL');
+const envDisablePostinstall: string | undefined = resolveConfig(
+  ResolveConfigVariables.DISABLE_POSTINSTALL
+);
 
 if (!!envToBool(envDisablePostinstall)) {
   console.log(
@@ -22,7 +25,7 @@ if (!!envToBool(envDisablePostinstall)) {
   process.exit(0);
 }
 
-const envSystemBinary: string | undefined = resolveConfig('SYSTEM_BINARY');
+const envSystemBinary: string | undefined = resolveConfig(ResolveConfigVariables.SYSTEM_BINARY);
 
 // value is ensured to be either an string (with more than 0 length) or being undefined
 if (typeof envSystemBinary === 'string') {
@@ -38,12 +41,15 @@ export async function postInstallEnsureBinary(
 
   if (!local) {
     // set "DOWNLOAD_DIR" to ~/.cache
-    setDefaultValue('DOWNLOAD_DIR', resolve(homedir(), '.cache', 'mongodb-binaries'));
+    setDefaultValue(
+      ResolveConfigVariables.DOWNLOAD_DIR,
+      resolve(homedir(), '.cache', 'mongodb-binaries')
+    );
   }
 
   if (version) {
     // if "version" is defined, apply it
-    setDefaultValue('VERSION', version);
+    setDefaultValue(ResolveConfigVariables.VERSION, version);
   }
 
   const binPath = await MongoBinary.getPath().catch((err) => {

--- a/packages/mongodb-memory-server-core/src/util/postinstallHelper.ts
+++ b/packages/mongodb-memory-server-core/src/util/postinstallHelper.ts
@@ -6,13 +6,13 @@ import { resolve } from 'path';
 import { MongoBinary } from './MongoBinary';
 import {
   envToBool,
-  reInitializePackageJson,
+  findPackageJson,
   resolveConfig,
   ResolveConfigVariables,
   setDefaultValue,
 } from './resolveConfig';
 
-reInitializePackageJson(process.env.INIT_CWD);
+findPackageJson(process.env.INIT_CWD);
 
 const envDisablePostinstall: string | undefined = resolveConfig(
   ResolveConfigVariables.DISABLE_POSTINSTALL

--- a/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
+++ b/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
@@ -4,8 +4,26 @@ import debug from 'debug';
 
 const log = debug('MongoMS:ResolveConfig');
 
+export enum ResolveConfigVariables {
+  DOWNLOAD_DIR = 'DOWNLOAD_DIR',
+  PLATFORM = 'PLATFORM',
+  ARCH = 'ARCH',
+  VERSION = 'VERSION',
+  DEBUG = 'DEBUG',
+  DOWNLOAD_MIRROR = 'DOWNLOAD_MIRROR',
+  DOWNLOAD_URL = 'DOWNLOAD_URL',
+  DISABLE_POSTINSTALL = 'DISABLE_POSTINSTALL',
+  SYSTEM_BINARY = 'SYSTEM_BINARY',
+  MD5_CHECK = 'MD5_CHECK',
+  USE_LINUX_LSB_RELEASE = 'USE_LINUX_LSB_RELEASE',
+  USE_LINUX_OS_RELEASE = 'USE_LINUX_OS_RELEASE',
+  USE_LINUX_ANY_RELEASE = 'USE_LINUX_ANY_RELEASE',
+  SKIP_OS_RELEASE = 'SKIP_OS_RELEASE',
+  ARCHIVE_NAME = 'ARCHIVE_NAME',
+}
+
 const ENV_CONFIG_PREFIX = 'MONGOMS_';
-export const defaultValues = new Map<string, string>();
+export const defaultValues = new Map<ResolveConfigVariables, string>();
 
 /**
  * Set an Default value for an specific key
@@ -13,7 +31,7 @@ export const defaultValues = new Map<string, string>();
  * @param key The Key the default value should be assigned to
  * @param value The Value what the default should be
  */
-export function setDefaultValue(key: string, value: string): void {
+export function setDefaultValue(key: ResolveConfigVariables, value: string): void {
   defaultValues.set(key, value);
 }
 
@@ -36,7 +54,7 @@ findPackageJson();
  * Resolve "variableName" with a prefix of "ENV_CONFIG_PREFIX"
  * @param variableName The variable to use
  */
-export function resolveConfig(variableName: string): string | undefined {
+export function resolveConfig(variableName: ResolveConfigVariables): string | undefined {
   return (
     process.env[`${ENV_CONFIG_PREFIX}${variableName}`] ??
     packageJsonConfig?.[camelCase(variableName)] ??
@@ -55,6 +73,6 @@ export function envToBool(env: string = ''): boolean {
 }
 
 // enable debug if "MONGOMS_DEBUG" is true
-if (envToBool(resolveConfig('DEBUG'))) {
+if (envToBool(resolveConfig(ResolveConfigVariables.DEBUG))) {
   debug.enable('MongoMS:*');
 }

--- a/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
+++ b/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
@@ -47,7 +47,6 @@ export function findPackageJson(directory?: string): void {
   log(`Using package.json at "${finderIterator.filename}"`);
   packageJsonConfig = finderIterator.value?.config?.mongodbMemoryServer ?? {};
 }
-export const reInitializePackageJson = findPackageJson; // TODO: remove this line on next minor version
 findPackageJson();
 
 /**

--- a/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
+++ b/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
@@ -59,7 +59,7 @@ findPackageJson();
 export function resolveConfig(variableName: ResolveConfigVariables): string | undefined {
   return (
     process.env[`${ENV_CONFIG_PREFIX}${variableName}`] ??
-    packageJsonConfig?.[camelCase(variableName)] ??
+    packageJsonConfig[camelCase(variableName)] ??
     defaultValues.get(variableName)
   );
 }

--- a/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
+++ b/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
@@ -22,7 +22,7 @@ export enum ResolveConfigVariables {
   ARCHIVE_NAME = 'ARCHIVE_NAME',
 }
 
-const ENV_CONFIG_PREFIX = 'MONGOMS_';
+export const ENV_CONFIG_PREFIX = 'MONGOMS_';
 export const defaultValues = new Map<ResolveConfigVariables, string>([
   // apply app-default values here
   [ResolveConfigVariables.VERSION, '4.0.20'],

--- a/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
+++ b/packages/mongodb-memory-server-core/src/util/resolveConfig.ts
@@ -23,7 +23,10 @@ export enum ResolveConfigVariables {
 }
 
 const ENV_CONFIG_PREFIX = 'MONGOMS_';
-export const defaultValues = new Map<ResolveConfigVariables, string>();
+export const defaultValues = new Map<ResolveConfigVariables, string>([
+  // apply app-default values here
+  [ResolveConfigVariables.VERSION, '4.0.20'],
+]);
 
 /**
  * Set an Default value for an specific key

--- a/packages/mongodb-memory-server-core/src/util/utils.ts
+++ b/packages/mongodb-memory-server-core/src/util/utils.ts
@@ -65,16 +65,19 @@ export async function killProcess(childprocess: ChildProcess, name: string): Pro
 
     return;
   }
+
   const timeoutTime = 1000 * 10;
   await new Promise((resolve, reject) => {
     let timeout = setTimeout(() => {
       log('killProcess timeout triggered, trying SIGKILL');
+
       if (!debug.enabled('MongoMS:utils')) {
         console.warn(
           'An Process didnt exit with signal "SIGINT" within 10 seconds, using "SIGKILL"!\n' +
             'Enable debug logs for more information'
         );
       }
+
       childprocess.kill('SIGKILL');
       timeout = setTimeout(() => {
         log('killProcess timeout triggered again, rejecting');

--- a/packages/mongodb-memory-server-core/src/util/utils.ts
+++ b/packages/mongodb-memory-server-core/src/util/utils.ts
@@ -62,6 +62,7 @@ export async function killProcess(childprocess: ChildProcess, name: string): Pro
   // check if the childProcess (via PID) is still alive (found thanks to https://github.com/nodkz/mongodb-memory-server/issues/411)
   if (!isAlive(childprocess.pid)) {
     log("killProcess: given childProcess's PID was not alive anymore");
+
     return;
   }
   const timeoutTime = 1000 * 10;
@@ -97,6 +98,7 @@ export async function killProcess(childprocess: ChildProcess, name: string): Pro
 export function isAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
+
     return true;
   } catch (err) {
     return false;

--- a/packages/mongodb-memory-server-core/src/util/utils.ts
+++ b/packages/mongodb-memory-server-core/src/util/utils.ts
@@ -49,7 +49,7 @@ export function isNullOrUndefined(val: unknown): val is null | undefined {
  */
 export function assertion(cond: unknown, error?: Error): asserts cond {
   if (!cond) {
-    throw error ?? new Error('Assert failed - no custom error [E019]');
+    throw error ?? new Error('Assert failed - no custom error');
   }
 }
 

--- a/packages/mongodb-memory-server-core/src/util/utils.ts
+++ b/packages/mongodb-memory-server-core/src/util/utils.ts
@@ -136,3 +136,12 @@ export async function statPath(path: string): Promise<Stats | undefined> {
     throw err;
   });
 }
+
+/**
+ * Like "fs.existsSync" but async
+ * uses "utils.statPath"
+ * @param path The Path to check for
+ */
+export async function pathExists(path: string): Promise<boolean> {
+  return !isNullOrUndefined(await statPath(path));
+}

--- a/packages/mongodb-memory-server-core/src/util/utils.ts
+++ b/packages/mongodb-memory-server-core/src/util/utils.ts
@@ -124,6 +124,7 @@ export function authDefault(opts: AutomaticAuth): Required<AutomaticAuth> {
 
 /**
  * Run "fs.promises.stat", but return "undefined" if error is "ENOENT"
+ * follows symlinks
  * @param path The Path to Stat
  * @throws if the error is not "ENOENT"
  */
@@ -140,6 +141,7 @@ export async function statPath(path: string): Promise<Stats | undefined> {
 /**
  * Like "fs.existsSync" but async
  * uses "utils.statPath"
+ * follows symlinks
  * @param path The Path to check for
  */
 export async function pathExists(path: string): Promise<boolean> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3456,7 +3456,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5075,7 +5075,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -6469,11 +6469,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6482,32 +6477,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -6558,11 +6531,6 @@ lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"


### PR DESCRIPTION
- add enum for all resolveConfig Variables
- remove alias "reInitializePackageJson"
- remove value "LATEST_VERSION"
- set default version inside resolveConfig
- test(MongoBinaryDownload): replace "process.env.variable" with "process.env[values.variable]"
- refactor "should use direct download"
- fix multiline test name
- refactor "should skip download if binary tar exists"
- refactor "should pick up proxy from env vars"
- refactor "should not reject unauthorized"
- refactor "should reject unauthorized"
- refactor "makeMD5check returns true"
- refactor "makeMD5check throws an error"
- refactor "disables makeMD5check validation"
- makeMD5check: add more tsdoc
- test(MongoBinary): replace "process.env.variable" with "process.env[values.variable]"
- test(MongoBinary): refactor tests
- test(MongoInstance): refactor to use "isAlive"
- test(resolveConfig): use "fs.promises" instead of "promisify"
- test(replset-single): add description on why to use "ts-expect-error"
- test(replset-multi): directly use db "admin"
- test(MongoMemoryServer): add description on why to use "ts-expect-error"
- refactor(MongoBinary): replace "promisify" with "fs.promises"
- refactor(MongoBinaryDownload): replace "promisify" with "fs.promises"
- refactor(getos): replace "promisify" with "fs.promises"
- add function "pathExists"
- remove function "locationExists"
- test that "statPath" throws an error if code is not "ENOENT"
- test that assertion throws default error if none provided
- assertion: remove error code from default error
- refactor(MongoBinaryDownload): replace "existsSync" with "utils.pathExists"
- add more tsdoc to "statPath" & "pathExists"
- remove function "getCachePath" (because it just an alias to `cache.get`, which is public anyway)
- getSystemPath: also check for execute permission
- feat(MongoInstance): run: add check that the mongoBinary has sufficient permissions
- feat(MongoBinaryDownload): startDownload: add check that the downloadDir has sufficient permissions
- eslintrc
  - add environment "node"
  - set rule "no-unused-expressions" to warn
  - comma-dangle: change "functions" to "never"
  - set rule "no-else-return" to "warn"
  - add rule "padding-line-between-statements" for "return"
  - add rule "padding-line-between-statements" for "if"
  - add rule "padding-line-between-statements" for "function" & "class"
  - add rule "padding-line-between-statements" for "import"

---

[here](https://unix.stackexchange.com/a/317446/325185) is an good explanation on which permissions are needed for an directory for this package