### PR TITLE
Fix/spawn

### DIFF
--- a/packages/mongodb-memory-server-core/package.json
+++ b/packages/mongodb-memory-server-core/package.json
@@ -31,7 +31,6 @@
   },
   "homepage": "https://github.com/nodkz/mongodb-memory-server",
   "devDependencies": {
-    "@types/cross-spawn": "^6.0.2",
     "@types/debug": "^4.1.5",
     "@types/dedent": "^0.7.0",
     "@types/find-cache-dir": "^3.2.0",
@@ -49,7 +48,6 @@
   "dependencies": {
     "@types/tmp": "^0.2.0",
     "camelcase": "^6.1.0",
-    "cross-spawn": "^7.0.3",
     "debug": "^4.2.0",
     "find-cache-dir": "^3.3.1",
     "find-package-json": "^1.2.0",

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -4,11 +4,11 @@ import path from 'path';
 import LockFile from 'lockfile';
 import mkdirp from 'mkdirp';
 import findCacheDir from 'find-cache-dir';
-import { execSync } from 'child_process';
 import MongoBinaryDownload from './MongoBinaryDownload';
 import resolveConfig, { envToBool, ResolveConfigVariables } from './resolveConfig';
 import debug from 'debug';
 import { assertion, isNullOrUndefined, pathExists } from './utils';
+import { spawnSync } from 'child_process';
 
 const log = debug('MongoMS:MongoBinary');
 
@@ -157,11 +157,8 @@ export class MongoBinary {
       binaryPath = await this.getSystemPath(options.systemBinary);
 
       if (binaryPath) {
-        if (binaryPath.indexOf(' ') >= 0) {
-          binaryPath = `"${binaryPath}"`;
-        }
-
-        const binaryVersion = execSync(`${binaryPath} --version`)
+        log(`Spawning binaryPath "${binaryPath}" to get version`);
+        const binaryVersion = spawnSync(binaryPath, ['--version'])
           .toString()
           .split('\n')[0]
           .split(' ')[2];

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -345,20 +345,6 @@ export class MongoInstance extends EventEmitter {
       }
     );
 
-    // killer.stdout?.on('data', (data) => {
-    //   this.debug(`[MongoKiller]: ${data}`);
-    // });
-
-    // killer.stderr?.on('data', (data) => {
-    //   this.debug(`[MongoKiller]: ${data}`);
-    // });
-
-    // ['exit', 'message', 'disconnect', 'error'].forEach((type) => {
-    //   killer.on(type, (...args) => {
-    //     this.debug(`[MongoKiller]: ${type} - ${JSON.stringify(args)}`);
-    //   });
-    // });
-
     killer.unref(); // dont force an exit on the fork when parent is exiting
 
     this.emit(MongoInstanceEvents.killerLaunched);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1782,13 +1782,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cross-spawn@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.2.tgz#168309de311cd30a2b8ae720de6475c2fbf33ac7"
-  integrity sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/debug@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
@@ -3347,7 +3340,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
- remove dependency `cross-spawn`, replace with `child_process`

this is because `cross-spawn` uses an extra shell to execute the binary in, which in result does not exit correctly (at least on windows)
replace `execSync` with `spawnSync` because of the same reason, `exec` & `execSync` use an extra shell too

-> the only drawback i can see is that the parent process dosnt have stdio with the mongo_killer process anymore (cannot be done without the parent waiting / killing the fork on exit)

## Related Issues

- fixes #193