### PR TITLE
feat(os-support): fall back to ubuntu release for arch-alikes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Must be one of the following:
 * **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
 * **revert**: Revert an commit
 * **dependencies**: Update field `dependencies` (/ `devDependencies`)
-* **release**: An Release Commit
+* **release**: A Release Commit
 
 look into [releaserc](../.releaserc.js) for corresponding versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,7 @@
 * **MongoBinaryDownloadUrl:** add case for Linux Mint 20 ([01a6bc6](https://github.com/nodkz/mongodb-memory-server/commit/01a6bc63f0e13a4528ee39ccae64390a8de48582))
 * **MongoBinaryDownloadUrl:** detect "linuxmint" and "linux mint" as linux mint ([fda4f72](https://github.com/nodkz/mongodb-memory-server/commit/fda4f7224d156680ac68c743c5a5a963070171dd)), closes [#403](https://github.com/nodkz/mongodb-memory-server/issues/403)
 * **MongoBinaryDownloadUrl:** fix win32 download generation ([d62b489](https://github.com/nodkz/mongodb-memory-server/commit/d62b4891a01fe40b5f00c21ee02f08b24a55d80c)), closes [#399](https://github.com/nodkz/mongodb-memory-server/issues/399)
-* **MongoBinaryDownloadUrl:** getArchiveName: throw error if platform is unkown ([9fc358b](https://github.com/nodkz/mongodb-memory-server/commit/9fc358b9b2997333b2121eabff16e91e543f3897))
+* **MongoBinaryDownloadUrl:** getArchiveName: throw error if platform is unknown ([9fc358b](https://github.com/nodkz/mongodb-memory-server/commit/9fc358b9b2997333b2121eabff16e91e543f3897))
 * **MongoInstance:** handle code "12" on windows ([718aed7](https://github.com/nodkz/mongodb-memory-server/commit/718aed7281c25c7198ea068a87b06924d77de8ba)), closes [#411](https://github.com/nodkz/mongodb-memory-server/issues/411)
 
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Works perfectly [with Travis CI](https://github.com/nodkz/graphql-compose-mongoo
 
 - [Installation](#installation)
   - [Requirements](#requirements)
-    - [Known Incompatibilities](#known-incompatibilities)
   - [mongodb-memory-server](#mongodb-memory-server)
   - [mongodb-memory-server-global](#mongodb-memory-server-global)
     - [mongodb-memory-server-global-x.x](#mongodb-memory-server-global-xx)
@@ -83,11 +82,6 @@ And one of those:
 - having an `/etc/os-release` file that is compliant to the [OS-Release Spec](https://www.freedesktop.org/software/systemd/man/os-release.html)
 - having an `/etc/*-release` file that is compliant to the [OS-Release Spec](https://www.freedesktop.org/software/systemd/man/os-release.html) (and does not include `lsb`)
 - manually specify which version & system should be used
-
-#### Known Incompatibilities
-
-- [ArchLinux](https://github.com/nodkz/mongodb-memory-server/issues/302) & [Alpine](https://github.com/nodkz/mongodb-memory-server/issues/347) do not have an official mongodb build
-- ArchLinux(Docker) does not have an `/etc/os-release` file by default
 
 ### mongodb-memory-server
 
@@ -288,7 +282,7 @@ MONGOMS_USE_LINUX_LSB_RELEASE=1 # Only try "lsb_release -a"
 MONGOMS_USE_LINUX_OS_RELEASE=1 # Only try to read "/etc/os-release"
 MONGOMS_USE_LINUX_ANYFILE_RELEASE=1 # Only try to read the first file found "/etc/*-release"
 MONGOMS_ARCHIVE_NAME="mongodb-linux-x86_64-4.0.0.tgz" # Specify what file / archive to download
-MONGOMS_SKIP_OS_RELEASE=1 # ignore error thrown in "tryOSRelease"
+MONGOMS_SKIP_OS_RELEASE=1 # ignore error thrown in "getOSRelease"
 ```
 
 ### Options which can be set via package.json's `config` section

--- a/packages/mongodb-memory-server-core/package.json
+++ b/packages/mongodb-memory-server-core/package.json
@@ -54,6 +54,7 @@
     "get-port": "^5.1.1",
     "https-proxy-agent": "^5.0.0",
     "lockfile": "^1.0.4",
+    "lookpath": "^1.1.0",
     "md5-file": "^5.0.0",
     "mkdirp": "^1.0.4",
     "mongodb": "^3.6.2",

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -256,7 +256,7 @@ export class MongoMemoryServer extends EventEmitter {
       case MongoMemoryServerStates.running:
       case MongoMemoryServerStates.starting:
       default:
-        throw new Error('Already in state running/starting or unkown');
+        throw new Error('Already in state running/starting or unknown');
     }
 
     if (!isNullOrUndefined(this._instanceInfo?.instance.childProcess)) {

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
@@ -33,7 +33,7 @@ describe('MongoMemoryServer', () => {
       expect(mongoServer._startUpInstance).toHaveBeenCalledTimes(1);
     });
 
-    it('"_startUpInstance" should use an different port if address is already in use (use same port for 2 servers)', async () => {
+    it('"_startUpInstance" should use a different port if address is already in use (use same port for 2 servers)', async () => {
       const mongoServer1 = await MongoMemoryServer.create({
         instance: { port: 27444 },
       });
@@ -64,7 +64,6 @@ describe('MongoMemoryServer', () => {
       await expect(mongoServer.start()).rejects.toThrow('unknown error');
 
       expect(mongoServer._startUpInstance).toHaveBeenCalledTimes(1);
-      expect(console.warn).toHaveBeenCalledTimes(1);
     });
 
     it('should make use of "AutomaticAuth" (ephemeralForTest)', async () => {

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
@@ -271,7 +271,7 @@ describe('MongoMemoryServer', () => {
           await mongoServer.start();
           fail('Expected "start" to fail');
         } catch (err) {
-          expect(err.message).toEqual('Already in state running/starting or unkown');
+          expect(err.message).toEqual('Already in state running/starting or unknown');
         }
       }
 
@@ -283,7 +283,7 @@ describe('MongoMemoryServer', () => {
           await mongoServer.start();
           fail('Expected "start" to fail');
         } catch (err) {
-          expect(err.message).toEqual('Already in state running/starting or unkown');
+          expect(err.message).toEqual('Already in state running/starting or unknown');
         }
       }
     });

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -93,7 +93,7 @@ export class MongoBinary {
             ? `MongoBinary: Error when removing download lock ${err}`
             : `MongoBinary: Download lock removed`
         );
-        res(); // we don't care if it was successful or not
+        res(undefined); // we don't care if it was successful or not
       });
     });
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts
@@ -247,7 +247,7 @@ export class MongoBinaryDownload {
     } else {
       throw new Error(
         `MongoBinaryDownload: unsupported archive ${mongoDBArchive} (downloaded from ${
-          this._downloadingUrl ?? 'unkown'
+          this._downloadingUrl ?? 'unknown'
         }). Broken archive from MongoDB Provider?`
       );
     }
@@ -255,7 +255,7 @@ export class MongoBinaryDownload {
     if (!(await pathExists(path.resolve(this.downloadDir, this.version, binaryName)))) {
       throw new Error(
         `MongoBinaryDownload: missing mongod binary in ${mongoDBArchive} (downloaded from ${
-          this._downloadingUrl ?? 'unkown'
+          this._downloadingUrl ?? 'unknown'
         }). Broken archive from MongoDB Provider?`
       );
     }
@@ -351,7 +351,7 @@ export class MongoBinaryDownload {
   }
 
   /**
-   * Downlaod given httpOptions to tempDownloadLocation, then move it to downloadLocation
+   * Download given httpOptions to tempDownloadLocation, then move it to downloadLocation
    * @param httpOptions The httpOptions directly passed to https.get
    * @param downloadLocation The location the File should be after the download
    * @param tempDownloadLocation The location the File should be while downloading

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -152,43 +152,46 @@ export class MongoBinaryDownloadUrl {
   getLinuxOSVersionString(os: LinuxOS): string {
     if (/ubuntu/i.test(os.dist)) {
       return this.getUbuntuVersionString(os);
-    } else if (/elementary OS/i.test(os.dist)) {
+    }
+    if (/elementary OS/i.test(os.dist)) {
       return this.getElementaryOSVersionString(os);
-    } else if (/suse/i.test(os.dist)) {
+    }
+    if (/suse/i.test(os.dist)) {
       return this.getSuseVersionString(os);
-    } else if (/rhel/i.test(os.dist) || /centos/i.test(os.dist) || /scientific/i.test(os.dist)) {
+    }
+    if (/rhel/i.test(os.dist) || /centos/i.test(os.dist) || /scientific/i.test(os.dist)) {
       return this.getRhelVersionString(os);
-    } else if (/fedora/i.test(os.dist)) {
+    }
+    if (/fedora/i.test(os.dist)) {
       return this.getFedoraVersionString(os);
-    } else if (/^linux\s?mint\s*$/i.test(os.dist)) {
+    }
+    if (/^linux\s?mint\s*$/i.test(os.dist)) {
       return this.getMintVersionString(os);
-    } else if (/debian/i.test(os.id_like || os.dist)) {
+    }
+    if (/debian/i.test(os.id_like || os.dist)) {
       return this.getDebianVersionString(os);
-    } else if (/arch/i.test(os.id_like || os.dist) || /(manjarolinux|arcolinux)/i.test(os.dist)) {
-      console.warn(
+    }
+    if (/arch/i.test(os.id_like || os.dist) || /(manjarolinux|arcolinux)/i.test(os.dist)) {
+      console.debug(
         `There is no official build of MongoDB for ArchLinux (${os.dist}). Falling back to Ubuntu release.`
       );
 
-      // falling back to ubuntu similar to https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=mongodb-bin
       return this.getUbuntuVersionString({
         os: 'linux',
         dist: 'Ubuntu Linux',
         release: '20.04',
       });
-    } else if (/alpine/i.test(os.dist)) {
-      console.warn('There is no official build of MongoDB for Alpine!');
-    } else if (/unknown/i.test(os.dist)) {
+    }
+    if (/unknown/i.test(os.dist)) {
       // "unknown" is likely to happen if no release file / command could be found
       console.warn(
         "Couldn't parse dist information, please report this to https://github.com/nodkz/mongodb-memory-server/issues"
       );
-    } else {
-      // warn if no case for the *parsed* distro is found
-      console.warn(`Unknown linux distro ${os.dist}`);
     }
 
-    // warn for the fallback
-    console.warn(`Falling back to legacy MongoDB build for os "${os.dist}"!`);
+    console.warn(
+      `Unknown/unsupported linux "${os.dist}(${os.id_like})". Falling back to legacy MongoDB build!`
+    );
 
     return this.getLegacyVersionString(os);
   }

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -1,5 +1,4 @@
 import getOS, { AnyOS, LinuxOS } from './getos';
-import { execSync } from 'child_process';
 import resolveConfig, { ResolveConfigVariables } from './resolveConfig';
 import debug from 'debug';
 import * as semver from 'semver';

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -153,9 +153,6 @@ export class MongoBinaryDownloadUrl {
     if (/ubuntu/i.test(os.dist)) {
       return this.getUbuntuVersionString(os);
     }
-    if (/elementary OS/i.test(os.dist)) {
-      return this.getElementaryOSVersionString(os);
-    }
     if (/suse/i.test(os.dist)) {
       return this.getSuseVersionString(os);
     }
@@ -164,9 +161,6 @@ export class MongoBinaryDownloadUrl {
     }
     if (/fedora/i.test(os.dist)) {
       return this.getFedoraVersionString(os);
-    }
-    if (/^linux\s?mint\s*$/i.test(os.dist)) {
-      return this.getMintVersionString(os);
     }
     if (/debian/i.test(os.id_like || os.dist)) {
       return this.getDebianVersionString(os);
@@ -254,56 +248,6 @@ export class MongoBinaryDownloadUrl {
       } else if (/^5/.test(release)) {
         name += '55';
       }
-    }
-
-    return name;
-  }
-
-  /**
-   * Get the version string for ElementaryOS
-   * @param os LinuxOS Object
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getElementaryOSVersionString(os: LinuxOS): string {
-    // Elementary specific - get used ubuntu version
-    const cmd = '/usr/bin/lsb_release -u -rs';
-    const ubuntuVersion = execSync(cmd);
-    try {
-      // confirm it is actually a version, otherwise throw an error
-      parseFloat(ubuntuVersion.toString());
-
-      return `ubuntu${ubuntuVersion.toString().replace('.', '').trim()}`;
-    } catch (err) {
-      console.error(`ElementaryOS "${cmd}" couldn\'t be executed!`);
-      throw err;
-    }
-  }
-
-  /**
-   * Get the version string for Linux Mint
-   * @param os LinuxOS Object
-   */
-  getMintVersionString(os: LinuxOS): string {
-    let name = 'ubuntu';
-    const mintMajorVer = parseInt(os.release ? os.release.split('.')[0] : os.release);
-
-    if (mintMajorVer < 17) {
-      throw new Error('Mint Versions under 17 are not supported!');
-    }
-
-    switch (mintMajorVer) {
-      case 17:
-        name += '1404';
-        break;
-      case 18:
-        name += '1604';
-        break;
-      case 20: // because "1804" binaries also work on "2004" (and because earlier versions than 4.4 are not available in "2004")
-      case 19:
-      default:
-        // a default to support versions > 19
-        name += '1804';
-        break;
     }
 
     return name;

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -149,13 +149,29 @@ export class MongoBinaryDownloadUrl {
    * @param os LinuxOS Object
    */
   getLinuxOSVersionString(os: LinuxOS): string {
-    if (/ubuntu/i.test(os.dist)) {
+    if (/ubuntu/i.test(os.id_like || os.dist)) {
+      if (/^linux\s?mint\s*$/i.test(os.dist)) {
+        const mintToUbuntuRelease: Record<number, string> = {
+          17: '14.04',
+          18: '16.04',
+          19: '18.04',
+          20: '20.04',
+        };
+
+        return this.getUbuntuVersionString({
+          ...os,
+          dist: 'ubuntu',
+          release:
+            mintToUbuntuRelease[parseInt(os.release.split('.')[0])] || mintToUbuntuRelease[20],
+        });
+      }
+
       return this.getUbuntuVersionString(os);
     }
     if (/suse/i.test(os.dist)) {
       return this.getSuseVersionString(os);
     }
-    if (/rhel/i.test(os.dist) || /centos/i.test(os.dist) || /scientific/i.test(os.dist)) {
+    if (/(rhel|centos|scientific)/i.test(os.dist)) {
       return this.getRhelVersionString(os);
     }
     if (/fedora/i.test(os.dist)) {

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -330,28 +330,27 @@ export class MongoBinaryDownloadUrl {
    * @param os LinuxOS Object
    */
   getUbuntuVersionString(os: LinuxOS): string {
-    let name = 'ubuntu';
-    const ubuntuVer: string[] = os.release ? os.release.split('.') : [];
-    const ubuntuMajor: number = parseInt(ubuntuVer[0], 10);
+    const ubuntuYear: number = parseInt(os.release.split('.')[0], 10);
 
     if (os.release === '14.10') {
-      return (name += '1410-clang');
-    } else if (ubuntuMajor >= 18) {
-      if (semver.satisfies(this.version, '3.x.x')) {
-        // there are no MongoDB 3.x binary distributions for ubuntu > 16.04
-        // https://www.mongodb.org/dl/linux/x86_64-ubuntu1604
-        return (name += '1604');
-      }
-      if (semver.satisfies(this.version, '<=4.3.x')) {
-        // there are no MongoDB 4.(x < 4) binary distributions for ubuntu > 18.04
-        // https://www.mongodb.org/dl/linux/x86_64-ubuntu1804
-        return (name += '1804');
-      }
+      return 'ubuntu1410-clang';
+    }
+
+    // there are no MongoDB 3.x binary distributions for ubuntu >= 18
+    // https://www.mongodb.org/dl/linux/x86_64-ubuntu1604
+    if (ubuntuYear >= 18 && semver.satisfies(this.version, '3.x.x')) {
+      return 'ubuntu1604';
+    }
+
+    // there are no MongoDB <=4.3.x binary distributions for ubuntu > 18
+    // https://www.mongodb.org/dl/linux/x86_64-ubuntu1804
+    if (ubuntuYear > 18 && semver.satisfies(this.version, '<=4.3.x')) {
+      return 'ubuntu1804';
     }
 
     // for all cases where its just "10.10" -> "1010"
     // and because the "04" version always exists for ubuntu, use that as default
-    return (name += `${ubuntuMajor || 14}04`);
+    return `ubuntu${ubuntuYear || 14}04`;
   }
 
   /**

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -149,7 +149,7 @@ export class MongoBinaryDownloadUrl {
    * @param os LinuxOS Object
    */
   getLinuxOSVersionString(os: LinuxOS): string {
-    if (/ubuntu/i.test(os.id_like || os.dist)) {
+    if (/ubuntu/i.test(os.id_like || '') || /ubuntu/i.test(os.dist)) {
       return this.getUbuntuVersionString(os);
     }
     if (/suse/i.test(os.dist)) {
@@ -161,10 +161,10 @@ export class MongoBinaryDownloadUrl {
     if (/fedora/i.test(os.dist)) {
       return this.getFedoraVersionString(os);
     }
-    if (/debian/i.test(os.id_like || os.dist)) {
+    if (/debian/i.test(os.id_like || '') || /debian/i.test(os.dist)) {
       return this.getDebianVersionString(os);
     }
-    if (/arch/i.test(os.id_like || os.dist) || /(manjaro|arco)linux/i.test(os.dist)) {
+    if (/arch/i.test(os.id_like || '') || /(arch|manjaro|arco)linux/i.test(os.dist)) {
       console.debug(
         `There is no official build of MongoDB for ArchLinux (${os.dist}). Falling back to Ubuntu release.`
       );
@@ -328,8 +328,7 @@ export class MongoBinaryDownloadUrl {
       return 'ubuntu1804';
     }
 
-    // for all cases where its just "10.10" -> "1010"
-    // and because the "04" version always exists for ubuntu, use that as default
+    // the "04" version always exists for ubuntu, use that as default
     return `ubuntu${ubuntuYear || 14}04`;
   }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -164,13 +164,13 @@ export class MongoBinaryDownloadUrl {
       return this.getRhelVersionString(os);
     } else if (/fedora/i.test(os.dist)) {
       return this.getFedoraVersionString(os);
-    } else if (/debian/i.test(os.dist)) {
-      return this.getDebianVersionString(os);
     } else if (/^linux\s?mint\s*$/i.test(os.dist)) {
       return this.getMintVersionString(os);
-    } else if (/(arch|manjarolinux)/i.test(os.dist)) {
+    } else if (/debian/i.test(os.id_like || os.dist)) {
+      return this.getDebianVersionString(os);
+    } else if (/arch/i.test(os.id_like || os.dist) || /(manjarolinux|arcolinux)/i.test(os.dist)) {
       console.warn(
-        `There is no official build of MongoDB for ArchLinux (using ${os.dist}). Falling back to ubuntu release.`
+        `There is no official build of MongoDB for ArchLinux (${os.dist}). Falling back to Ubuntu release.`
       );
       // falling back to ubuntu similar to https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=mongodb-bin
       return this.getUbuntuVersionString({

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -150,22 +150,6 @@ export class MongoBinaryDownloadUrl {
    */
   getLinuxOSVersionString(os: LinuxOS): string {
     if (/ubuntu/i.test(os.id_like || os.dist)) {
-      if (/^linux\s?mint\s*$/i.test(os.dist)) {
-        const mintToUbuntuRelease: Record<number, string> = {
-          17: '14.04',
-          18: '16.04',
-          19: '18.04',
-          20: '20.04',
-        };
-
-        return this.getUbuntuVersionString({
-          ...os,
-          dist: 'ubuntu',
-          release:
-            mintToUbuntuRelease[parseInt(os.release.split('.')[0])] || mintToUbuntuRelease[20],
-        });
-      }
-
       return this.getUbuntuVersionString(os);
     }
     if (/suse/i.test(os.dist)) {
@@ -293,6 +277,40 @@ export class MongoBinaryDownloadUrl {
    */
   getUbuntuVersionString(os: LinuxOS): string {
     const ubuntuYear: number = parseInt(os.release.split('.')[0], 10);
+
+    if (/^linux\s?mint\s*$/i.test(os.dist)) {
+      const mintToUbuntuRelease: Record<number, string> = {
+        17: '14.04',
+        18: '16.04',
+        19: '18.04',
+        20: '20.04',
+      };
+
+      return this.getUbuntuVersionString({
+        ...os,
+        dist: 'ubuntu',
+        release: mintToUbuntuRelease[parseInt(os.release.split('.')[0])] || mintToUbuntuRelease[20],
+      });
+    }
+
+    if (/^elementary\s?OS\s*$/i.test(os.dist)) {
+      const elementaryToUbuntuRelease: Record<number, string> = {
+        3: '14.04',
+        4: '16.04',
+        5: '18.04',
+        6: '20.04',
+      };
+
+      // untangle elemenatary versioning from hell https://en.wikipedia.org/wiki/Elementary_OS#Development
+      const [elementaryMajor, elementaryMinor] = os.release.split('.').map((el) => parseInt(el));
+      const realMajor = elementaryMajor || elementaryMinor;
+
+      return this.getUbuntuVersionString({
+        ...os,
+        dist: 'ubuntu',
+        release: elementaryToUbuntuRelease[realMajor] || elementaryToUbuntuRelease[6],
+      });
+    }
 
     if (os.release === '14.10') {
       return 'ubuntu1410-clang';

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -164,7 +164,7 @@ export class MongoBinaryDownloadUrl {
     if (/debian/i.test(os.id_like || os.dist)) {
       return this.getDebianVersionString(os);
     }
-    if (/arch/i.test(os.id_like || os.dist) || /(manjarolinux|arcolinux)/i.test(os.dist)) {
+    if (/arch/i.test(os.id_like || os.dist) || /(manjaro|arco)linux/i.test(os.dist)) {
       console.debug(
         `There is no official build of MongoDB for ArchLinux (${os.dist}). Falling back to Ubuntu release.`
       );

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -427,7 +427,7 @@ export class MongoInstance extends EventEmitter {
       this.emit(MongoInstanceEvents.instancePrimary);
     } else if (/member [\d\.:]+ is now in state \w+/i.test(line)) {
       // "[\d\.:]+" matches "0.0.0.0:0000" (IP:PORT)
-      const state = /member [\d\.:]+ is now in state (\w+)/i.exec(line)?.[1] ?? 'UNknown';
+      const state = /member [\d\.:]+ is now in state (\w+)/i.exec(line)?.[1] ?? 'UNKNOWN';
       this.emit(MongoInstanceEvents.instanceReplState, state);
 
       if (state !== 'PRIMARY') {

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -135,7 +135,7 @@ export class MongoInstance extends EventEmitter {
    * @param msg The Message to log
    */
   private debug(msg: string): void {
-    const port = this.instanceOpts.port ?? 'unkown';
+    const port = this.instanceOpts.port ?? 'unknown';
     log(`Mongo[${port}]: ${msg}`);
   }
 
@@ -427,7 +427,7 @@ export class MongoInstance extends EventEmitter {
       this.emit(MongoInstanceEvents.instancePrimary);
     } else if (/member [\d\.:]+ is now in state \w+/i.test(line)) {
       // "[\d\.:]+" matches "0.0.0.0:0000" (IP:PORT)
-      const state = /member [\d\.:]+ is now in state (\w+)/i.exec(line)?.[1] ?? 'UNKOWN';
+      const state = /member [\d\.:]+ is now in state (\w+)/i.exec(line)?.[1] ?? 'UNknown';
       this.emit(MongoInstanceEvents.instanceReplState, state);
 
       if (state !== 'PRIMARY') {

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -85,6 +85,82 @@ describe('MongoBinaryDownloadUrl', () => {
       );
     });
 
+    describe('for linux mint', () => {
+      it('should return a archive name for Linux Mint 17', async () => {
+        const du = new MongoBinaryDownloadUrl({
+          platform: 'linux',
+          arch: 'x64',
+          version: '4.4.1',
+          os: {
+            os: 'linux',
+            dist: 'Linux Mint',
+            release: '17',
+            id_like: 'ubuntu',
+          },
+        });
+
+        expect(await du.getDownloadUrl()).toBe(
+          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1404-4.4.1.tgz'
+        );
+      });
+
+      it('should return a archive name for Linux Mint 18', async () => {
+        const du = new MongoBinaryDownloadUrl({
+          platform: 'linux',
+          arch: 'x64',
+          version: '4.4.1',
+          os: {
+            os: 'linux',
+            dist: 'Linux Mint',
+            release: '18',
+            id_like: 'ubuntu',
+          },
+        });
+
+        expect(await du.getDownloadUrl()).toBe(
+          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.4.1.tgz'
+        );
+      });
+
+      it('should return a archive name for Linux Mint 19', async () => {
+        const du = new MongoBinaryDownloadUrl({
+          platform: 'linux',
+          arch: 'x64',
+          version: '4.4.1',
+          os: {
+            os: 'linux',
+            dist: 'Linux Mint',
+            release: '19',
+            id_like: 'ubuntu',
+          },
+        });
+
+        expect(await du.getDownloadUrl()).toBe(
+          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.4.1.tgz'
+        );
+      });
+
+      it('should return a archive name for Linux Mint 20', async () => {
+        const du = new MongoBinaryDownloadUrl({
+          platform: 'linux',
+          arch: 'x64',
+          version: '4.4.1',
+          os: {
+            os: 'linux',
+            dist: 'Linux Mint',
+            release: '20',
+            id_like: 'ubuntu',
+          },
+        });
+
+        expect(await du.getDownloadUrl()).toBe(
+          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.1.tgz'
+        );
+      });
+    });
+
+    describe('for elementary', () => {});
+
     it('for manjaro', async () => {
       const du = new MongoBinaryDownloadUrl({
         platform: 'linux',

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -210,7 +210,7 @@ describe('MongoBinaryDownloadUrl', () => {
       expect(await du.getDownloadUrl()).toBe(
         'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.3.tgz'
       );
-      expect(console.warn).toHaveBeenCalledTimes(2);
+      expect(console.warn).toHaveBeenCalledTimes(1); // fallback warning
     });
 
     it('should allow overwrite with "ARCHIVE_NAME"', async () => {
@@ -479,7 +479,7 @@ describe('MongoBinaryDownloadUrl', () => {
       })
     ).toBe('');
 
-    expect(console.warn).toHaveBeenCalledTimes(2); // once "Unknown linux distro Peppermint" and once "Falling back to legacy MongoDB build!"
+    expect(console.warn).toHaveBeenCalledTimes(1); // fallback warning
   });
 
   describe('getLegacyVersionString', () => {

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -94,6 +94,7 @@ describe('MongoBinaryDownloadUrl', () => {
           os: 'linux',
           dist: 'ManjaroLinux',
           release: '20.2',
+          id_like: 'arch',
         },
       });
       expect(await du.getDownloadUrl()).toBe(
@@ -110,6 +111,24 @@ describe('MongoBinaryDownloadUrl', () => {
           os: 'linux',
           dist: 'Arch',
           release: 'rolling',
+          id_like: 'arch',
+        },
+      });
+      expect(await du.getDownloadUrl()).toBe(
+        'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.2.tgz'
+      );
+    });
+
+    it('for unpopular arch', async () => {
+      const du = new MongoBinaryDownloadUrl({
+        platform: 'linux',
+        arch: 'x64',
+        version: '4.4.2',
+        os: {
+          os: 'linux',
+          dist: 'ArchStrike',
+          release: 'rolling',
+          id_like: 'arch',
         },
       });
       expect(await du.getDownloadUrl()).toBe(

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -148,7 +148,7 @@ describe('MongoBinaryDownloadUrl', () => {
           os: {
             os: 'linux',
             dist: 'Linux Mint',
-            release: '20',
+            release: '20.1',
             id_like: 'ubuntu',
           },
         });
@@ -159,7 +159,43 @@ describe('MongoBinaryDownloadUrl', () => {
       });
     });
 
-    describe('for elementary', () => {});
+    describe('for elementary', () => {
+      it('should return a archive name for elementary 0.3', async () => {
+        const du = new MongoBinaryDownloadUrl({
+          platform: 'linux',
+          arch: 'x64',
+          version: '4.4.1',
+          os: {
+            os: 'linux',
+            dist: 'elementary OS',
+            release: '0.3',
+            id_like: 'ubuntu',
+          },
+        });
+
+        expect(await du.getDownloadUrl()).toBe(
+          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1404-4.4.1.tgz'
+        );
+      });
+
+      it('should return a archive name for elementary 5', async () => {
+        const du = new MongoBinaryDownloadUrl({
+          platform: 'linux',
+          arch: 'x64',
+          version: '4.4.1',
+          os: {
+            os: 'linux',
+            dist: 'elementary OS',
+            release: '5.1',
+            id_like: 'ubuntu',
+          },
+        });
+
+        expect(await du.getDownloadUrl()).toBe(
+          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.4.1.tgz'
+        );
+      });
+    });
 
     it('for manjaro', async () => {
       const du = new MongoBinaryDownloadUrl({

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -85,6 +85,38 @@ describe('MongoBinaryDownloadUrl', () => {
       );
     });
 
+    it('for manjaro', async () => {
+      const du = new MongoBinaryDownloadUrl({
+        platform: 'linux',
+        arch: 'x64',
+        version: '4.4.2',
+        os: {
+          os: 'linux',
+          dist: 'ManjaroLinux',
+          release: '20.2',
+        },
+      });
+      expect(await du.getDownloadUrl()).toBe(
+        'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.2.tgz'
+      );
+    });
+
+    it('for arch', async () => {
+      const du = new MongoBinaryDownloadUrl({
+        platform: 'linux',
+        arch: 'x64',
+        version: '4.4.2',
+        os: {
+          os: 'linux',
+          dist: 'Arch',
+          release: 'rolling',
+        },
+      });
+      expect(await du.getDownloadUrl()).toBe(
+        'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.2.tgz'
+      );
+    });
+
     describe('for win32 & windows', () => {
       it('3.6 (win32)', async () => {
         const du = new MongoBinaryDownloadUrl({

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -401,69 +401,7 @@ describe('MongoBinaryDownloadUrl', () => {
       ).toBe('debian92');
     });
   });
-
-  describe('getMintVersionString', () => {
-    const downloadUrl = new MongoBinaryDownloadUrl({
-      platform: 'linux',
-      arch: 'x64',
-      version: '3.6.3',
-    });
-
-    it('should throw an error if an version below Linux Mint 17 is given', () => {
-      try {
-        downloadUrl.getMintVersionString({
-          os: 'linux',
-          dist: 'Linux Mint',
-          release: '16',
-        });
-        fail('Expected "getMintVersionString" to throw');
-      } catch (err) {
-        expect(err.message).toEqual('Mint Versions under 17 are not supported!');
-      }
-    });
-
-    it('should return a archive name for Linux Mint 17', () => {
-      expect(
-        downloadUrl.getMintVersionString({
-          os: 'linux',
-          dist: 'Linux Mint',
-          release: '17',
-        })
-      ).toBe('ubuntu1404');
-    });
-
-    it('should return a archive name for Linux Mint 18', () => {
-      expect(
-        downloadUrl.getMintVersionString({
-          os: 'linux',
-          dist: 'Linux Mint',
-          release: '18',
-        })
-      ).toBe('ubuntu1604');
-    });
-
-    it('should return a archive name for Linux Mint 19', () => {
-      expect(
-        downloadUrl.getMintVersionString({
-          os: 'linux',
-          dist: 'LinuxMint',
-          release: '19',
-        })
-      ).toBe('ubuntu1804');
-    });
-
-    it('should return a archive name for Linux Mint 20', () => {
-      expect(
-        downloadUrl.getMintVersionString({
-          os: 'linux',
-          dist: 'Linux Mint',
-          release: '20',
-        })
-      ).toBe('ubuntu1804');
-    });
-  });
-
-  it('shouldnt detect linux mint when using peppermint', () => {
+  it("shouldn't detect linux mint when using peppermint", () => {
     jest.spyOn(console, 'warn').mockImplementation(() => void 0);
     const downloadUrl = new MongoBinaryDownloadUrl({
       platform: 'linux',

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -225,33 +225,33 @@ describe('MongoBinaryDownloadUrl', () => {
       defaultValues.delete(ResolveConfigVariables.ARCHIVE_NAME);
     });
 
-    it('should throw an error if platform is unkown (getArchiveName)', async () => {
+    it('should throw an error if platform is unknown (getArchiveName)', async () => {
       // this is to test the default case in "getArchiveName"
       const du = new MongoBinaryDownloadUrl({
         platform: 'linux',
         arch: 'x64',
         version: '4.0.0',
       });
-      du.platform = 'unkown';
+      du.platform = 'unknown';
       try {
         await du.getArchiveName();
         fail('Expected "getArchiveName" to throw');
       } catch (err) {
-        expect(err.message).toEqual('Unkown Platform "unkown"');
+        expect(err.message).toEqual('Unknown Platform "unknown"');
       }
     });
 
-    it('should throw an error if platform is unkown (translatePlatform)', async () => {
+    it('should throw an error if platform is unknown (translatePlatform)', async () => {
       // this is to test the default case in "translatePlatform"
       try {
         new MongoBinaryDownloadUrl({
-          platform: 'unkown',
+          platform: 'unknown',
           arch: 'x64',
           version: '4.0.0',
         });
         fail('Expected "translatePlatform" to throw');
       } catch (err) {
-        expect(err.message).toEqual('Unkown Platform "unkown"');
+        expect(err.message).toEqual('Unknown Platform "unknown"');
       }
     });
   });

--- a/packages/mongodb-memory-server-core/src/util/__tests__/getos.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/getos.test.ts
@@ -1,6 +1,7 @@
 import { promises as fsPromises, Stats } from 'fs';
 import getOS, { LinuxOS } from '../getos';
 import os from 'os';
+import { FileNotFoundError } from '../errors';
 
 const UbuntuLSB = `DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=20.04
@@ -41,9 +42,7 @@ describe('getLinuxInformation', () => {
         });
       }
 
-      return new Promise((_resolve, reject) => {
-        reject('not mocked');
-      });
+      throw new FileNotFoundError();
     });
 
     const result = (await getOS()) as LinuxOS;
@@ -75,9 +74,7 @@ describe('getLinuxInformation', () => {
         });
       }
 
-      return new Promise((_resolve, reject) => {
-        reject('not mocked');
-      });
+      throw new FileNotFoundError();
     });
 
     const result = (await getOS()) as LinuxOS;

--- a/packages/mongodb-memory-server-core/src/util/__tests__/getos.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/getos.test.ts
@@ -1,0 +1,89 @@
+import { promises as fsPromises, Stats } from 'fs';
+import getOS, { LinuxOS } from '../getos';
+import os from 'os';
+
+const UbuntuLSB = `DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=20.04
+DISTRIB_CODENAME=focal
+DISTRIB_DESCRIPTION="Ubuntu 20.04.1 LTS"`;
+
+const UbuntuOSRelease = `NAME="Ubuntu"
+VERSION="20.04.1 LTS (Focal Fossa)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 20.04.1 LTS"
+VERSION_ID="20.04"
+VERSION_CODENAME=focal
+UBUNTU_CODENAME=focal`;
+
+const MintLSB = `DISTRIB_ID=LinuxMint
+DISTRIB_RELEASE=20
+DISTRIB_CODENAME=whatever
+DISTRIB_DESCRIPTION="Linux Mint 20 IDK"`;
+
+// only testing linux systems anyways
+jest.spyOn(os, 'platform').mockReturnValueOnce('linux');
+
+describe('getLinuxInformation', () => {
+  it('should return ubuntu info', async () => {
+    jest.spyOn(fsPromises, 'stat').mockRejectedValueOnce({ code: 'ENOENT' });
+
+    jest.spyOn(fsPromises, 'readFile').mockImplementation((filePath) => {
+      if (filePath === '/etc/lsb-release') {
+        return new Promise((resolve) => {
+          resolve(UbuntuLSB);
+        });
+      }
+
+      if (filePath === '/etc/os-release') {
+        return new Promise((resolve) => {
+          resolve(UbuntuOSRelease);
+        });
+      }
+
+      return new Promise((_resolve, reject) => {
+        reject('not mocked');
+      });
+    });
+
+    const result = (await getOS()) as LinuxOS;
+
+    expect(result.os).toBe('linux');
+    expect(result.dist).toBe('Ubuntu');
+    expect(result.id_like).toBe('debian');
+  });
+
+  it('linux mint should fall back to ubuntu', async () => {
+    jest.spyOn(fsPromises, 'stat').mockResolvedValueOnce({} as Stats);
+
+    jest.spyOn(fsPromises, 'readFile').mockImplementation((filePath) => {
+      if (filePath === '/etc/lsb-release') {
+        return new Promise((resolve) => {
+          resolve(MintLSB);
+        });
+      }
+
+      if (filePath === '/etc/os-release') {
+        return new Promise((resolve) => {
+          resolve(UbuntuOSRelease);
+        });
+      }
+
+      if (filePath === '/etc/upstream-release/lsb-release') {
+        return new Promise((resolve) => {
+          resolve(UbuntuLSB);
+        });
+      }
+
+      return new Promise((_resolve, reject) => {
+        reject('not mocked');
+      });
+    });
+
+    const result = (await getOS()) as LinuxOS;
+
+    expect(result.os).toBe('linux');
+    expect(result.dist).toBe('Ubuntu');
+    expect(result.id_like).toBe('debian');
+  });
+});

--- a/packages/mongodb-memory-server-core/src/util/errors.ts
+++ b/packages/mongodb-memory-server-core/src/util/errors.ts
@@ -1,0 +1,4 @@
+export class FileNotFoundError {
+  public code = 'ENOENT';
+  constructor(public message: string = 'file not found') {}
+}

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -97,6 +97,7 @@ async function getLinuxInformation(): Promise<LinuxOS> {
   const osOut = await tryOSRelease();
 
   if (!isNullOrUndefined(lsbOut)) {
+    // add id_like info if available
     return { ...lsbOut, id_like: osOut?.id_like };
   }
 

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -22,6 +22,7 @@ const OSRegex = {
   /** uses VERSION_CODENAME */
   codename: /^version_codename\s*=\s*(.*)$/im,
   release: /^version_id\s*=\s*"?(.*)"?$/im,
+  id_like: /^id_like\s*=\s*"?(.*)"?$/im,
 };
 
 export interface OtherOS {
@@ -33,6 +34,7 @@ export interface LinuxOS extends OtherOS {
   dist: string;
   release: string;
   codename?: string;
+  id_like?: string;
 }
 
 export type AnyOS = OtherOS | LinuxOS;
@@ -91,13 +93,12 @@ async function getLinuxInformation(): Promise<LinuxOS> {
 
   log('Trying LSB-Release');
   const lsbOut = await tryLSBRelease();
-
-  if (!isNullOrUndefined(lsbOut)) {
-    return lsbOut;
-  }
-
   log('Trying OS-Release');
   const osOut = await tryOSRelease();
+
+  if (!isNullOrUndefined(lsbOut)) {
+    return { ...lsbOut, id_like: osOut?.id_like };
+  }
 
   if (!isNullOrUndefined(osOut)) {
     return osOut;

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -7,6 +7,7 @@ import debug from 'debug';
 import { isNullOrUndefined, readFileAndParseLinuxOs } from '../utils';
 import { promisify } from 'util';
 import { lookpath } from 'lookpath';
+import { FileNotFoundError } from '../errors';
 
 const log = debug('MongoMS:getos');
 
@@ -161,7 +162,7 @@ async function getFirstReleaseFile(): Promise<LinuxOS | undefined> {
   )[0];
 
   if (isNullOrUndefined(file) || file.length <= 0) {
-    throw new Error('No release file found!');
+    throw new FileNotFoundError('No release file found!');
   }
 
   const os = await fspromises.readFile(join('/etc/', file));

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -10,9 +10,9 @@ const log = debug('MongoMS:getos');
 
 /** Collection of Regexes for "lsb_release -a" or plain lsb file parsing */
 const LSBRegex = {
-  name: /^(distributor id:\s*|DISTRIB_ID=)(.*)$/im,
-  codename: /^(codename:\s*|DISTRIB_CODENAME=)(.*)$/im,
-  release: /^(release:\s*|DISTRIB_RELEASE=)(.*)$/im,
+  name: /^(distributor id:|DISTRIB_ID=)\s*(.*)$/im,
+  codename: /^(codename:|DISTRIB_CODENAME=)\s*(.*)$/im,
+  release: /^(release:|DISTRIB_RELEASE=)\s*(.*)$/im,
 };
 
 /** Collection of Regexes for "/etc/os-release" parsing */
@@ -222,5 +222,6 @@ function parseOS(input: string): LinuxOS {
     dist: input.match(OSRegex.name)?.[1] ?? 'unknown',
     codename: input.match(OSRegex.codename)?.[1],
     release: input.match(OSRegex.release)?.[1] ?? '',
+    id_like: input.match(OSRegex.id_like)?.[1],
   };
 }

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -52,7 +52,7 @@ export async function getOS(): Promise<AnyOS> {
 
   // Linux is a special case.
   if (osName === 'linux') {
-    return await getLinuxInfomation();
+    return await getLinuxInformation();
   }
 
   return { os: osName };
@@ -60,8 +60,8 @@ export async function getOS(): Promise<AnyOS> {
 
 export default getOS;
 
-/** Function to outsource Linux Infomation Parsing */
-async function getLinuxInfomation(): Promise<LinuxOS> {
+/** Function to outsource Linux Information Parsing */
+async function getLinuxInformation(): Promise<LinuxOS> {
   // Structure of this function:
   // 1. try lsb_release
   // (if not 1) 2. try /etc/os-release
@@ -110,12 +110,12 @@ async function getLinuxInfomation(): Promise<LinuxOS> {
     return releaseOut;
   }
 
-  log('Couldnt find an release file');
+  log("Couldn't find an release file");
 
-  // if none has worked, return unkown
+  // if none has worked, return unknown
   return {
     os: 'linux',
-    dist: 'unkown',
+    dist: 'unknown',
     release: '',
   };
 }
@@ -204,7 +204,7 @@ async function tryFirstReleaseFile(): Promise<LinuxOS | undefined> {
 function parseLSB(input: string): LinuxOS {
   return {
     os: 'linux',
-    dist: input.match(LSBRegex.name)?.[1] ?? 'unkown',
+    dist: input.match(LSBRegex.name)?.[1] ?? 'unknown',
     codename: input.match(LSBRegex.codename)?.[1],
     release: input.match(LSBRegex.release)?.[1] ?? '',
   };
@@ -214,7 +214,7 @@ function parseLSB(input: string): LinuxOS {
 function parseOS(input: string): LinuxOS {
   return {
     os: 'linux',
-    dist: input.match(OSRegex.name)?.[1] ?? 'unkown',
+    dist: input.match(OSRegex.name)?.[1] ?? 'unknown',
     codename: input.match(OSRegex.codename)?.[1],
     release: input.match(OSRegex.release)?.[1] ?? '',
   };

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -112,7 +112,7 @@ async function getLinuxInformation(): Promise<LinuxOS> {
     return releaseOut;
   }
 
-  log("Couldn't find an release file");
+  log("Couldn't find a release file");
 
   // if none has worked, return unknown
   return {

--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import { promises as fspromises } from 'fs';
 import { platform } from 'os';
 import { execSync } from 'child_process';
 import { join } from 'path';
@@ -127,8 +127,8 @@ async function getLinuxInformation(): Promise<LinuxOS> {
 async function tryLSBRelease(): Promise<LinuxOS | undefined> {
   try {
     // use upstream lsb file if it exists (like in linux mint)
-    if (fs.existsSync('/etc/upstream-release/lsb-release')) {
-      return parseLSB(fs.readFileSync('/etc/upstream-release/lsb-release', 'utf8'));
+    if (await fspromises.stat('/etc/upstream-release/lsb-release')) {
+      return parseLSB(await fspromises.readFile('/etc/upstream-release/lsb-release', 'utf8'));
     }
 
     // exec this for safety, because "/etc/lsb-release" could be changed to another file
@@ -149,7 +149,7 @@ async function tryLSBRelease(): Promise<LinuxOS | undefined> {
  */
 async function tryOSRelease(): Promise<LinuxOS | undefined> {
   try {
-    const os = fs.readFileSync('/etc/os-release', 'utf-8');
+    const os = await fspromises.readFile('/etc/os-release', 'utf-8');
 
     return parseOS(os.toString());
   } catch (err) {
@@ -174,7 +174,7 @@ async function tryOSRelease(): Promise<LinuxOS | undefined> {
  */
 async function tryFirstReleaseFile(): Promise<LinuxOS | undefined> {
   try {
-    const file = fs.readdirSync('/etc').filter(
+    const file = (await fspromises.readdir('/etc')).filter(
       (v) =>
         // match if file ends with "-release"
         v.match(/.*-release$/im) &&
@@ -186,7 +186,7 @@ async function tryFirstReleaseFile(): Promise<LinuxOS | undefined> {
       throw new Error('No release file found!');
     }
 
-    const os = fs.readFileSync(join('/etc/', file));
+    const os = await fspromises.readFile(join('/etc/', file));
 
     return parseOS(os.toString());
   } catch (err) {

--- a/packages/mongodb-memory-server-core/src/util/utils.ts
+++ b/packages/mongodb-memory-server-core/src/util/utils.ts
@@ -4,6 +4,7 @@ import { ChildProcess } from 'child_process';
 import { AutomaticAuth } from '../MongoMemoryServer';
 import { promises as fspromises, Stats } from 'fs';
 import { LinuxOS } from './getos';
+import { FileNotFoundError } from './errors';
 
 const log = debug('MongoMS:utils');
 
@@ -169,5 +170,5 @@ export async function readFileAndParseLinuxOs(
     return parse(await fspromises.readFile(existingPath, 'utf8'));
   }
 
-  throw new Error('No file found');
+  throw new FileNotFoundError('No file found');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6597,6 +6597,11 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+lookpath@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/lookpath/-/lookpath-1.1.0.tgz#932d68371a2f0b4a5644f03d6a2b4728edba96d2"
+  integrity sha512-B9NM7XpVfkyWqfOBI/UW0kVhGw7pJztsduch+1wkbYDi90mYK6/InFul3lG0hYko/VEcVMARVBJ5daFRc5aKCw==
+
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"


### PR DESCRIPTION
## Related Issues
- fixes #419
- fixes #302

I figured that the approach used in the aur mongodb-bin package (https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=mongodb-bin) should easily work on arch-alikes without much changes. For me it does.