### PR TITLE
Add debian "testing" release

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -172,7 +172,7 @@ export default class MongoBinaryDownloadUrl {
   getDebianVersionString(os: LinuxOS): string {
     let name = 'debian';
     const release: number = parseFloat(os.release);
-    if (release >= 10 || os.release === 'unstable') {
+    if (release >= 10 || ['unstable', 'testing'].includes(os.release)) {
       name += '10';
     } else if (release >= 9) {
       name += '92';


### PR DESCRIPTION
Hey there, I had an issue with getting this up and running on debian/testing. Here's a  debug log snippet
```
  MongoMS:MongoBinary MongoBinary options: {"downloadDir":"/home/jnes/TILLY/delta/jest/node_modules/.cache/mongodb-memory-server/mongodb-binaries","platform":"linux","arch":"x64","version":"4.0.14"} +0ms
  MongoMS:getos Trying LSB-Release +0ms
  MongoMS:MongoBinaryDownloadUrl Using "mongodb-linux-x86_64-debian-4.0.14.tgz" as the Archive String +0ms
  MongoMS:MongoBinaryDownloadUrl Using "https://fastdl.mongodb.org" as the mirror +0ms
  MongoMS:MongoBinaryDownload Downloading: "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian-4.0.14.tgz" +0ms
  MongoMS:MongoBinaryDownload trying to download https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian-4.0.14.tgz +0ms
Error: Status Code is 403 (MongoDB's 404)
``` 

The problem here is not only the version number (using latest gives the same error) but also that it seems `debian` should be suffixed with its version number too.

Since Debian unstable falls back to 10, I think it should be OK for the slightly less bleeding edge Debian testing to do the same.


### Related issue
There's none but one can reproduce by installing debian testing, whose `lsb_release -a` looks like so
```
No LSB modules are available.
Distributor ID: Debian
Description:    Debian GNU/Linux bullseye/sid
Release:        testing
Codename:       bullseye
```