### PR TITLE
fix(MongoMemoryServer): change state to stopped when start fails

### DIFF
--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -277,6 +277,8 @@ export class MongoMemoryServer extends EventEmitter {
         console.warn('Starting the instance failed, enable debug for more information');
       }
 
+      this.stateChange(MongoMemoryServerStates.stopped);
+
       throw err;
     });
 

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
@@ -63,6 +63,7 @@ describe('MongoMemoryServer', () => {
 
       await expect(mongoServer.start()).rejects.toThrow('unknown error');
 
+      expect(mongoServer.state).toStrictEqual(MongoMemoryServerStates.stopped);
       expect(mongoServer._startUpInstance).toHaveBeenCalledTimes(1);
       expect(console.warn).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
When the server fails to start, the state is left is `running`. 

changing the state to `stopped` allows implementing more complex scenarios over the testkit. 
For example, in case the testkit failed to find a proper binary, I can set the `MONGOMS_DOWNLOAD_URL` environment variable and try again.

ATM, doing so throws because `start` [expects](https://github.com/nodkz/mongodb-memory-server/blob/beta/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts#L256) the state to either be `new` or `stopped`