### PR TITLE
fix: improve error message `"instanceInfo" is undefined` for users who upgraded from v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ And one of those:
 
 ### Configuring which mongod binary to use
 
-The default behaviour is that version ~~`latest`~~`4.0.25` for your OS will be downloaded. By setting [Environment variables](https://nodkz.github.io/mongodb-memory-server/docs/api/config-options) you are able to specify which version and binary will be downloaded:
+The default behavior is that version ~~`latest`~~`4.0.25` for your OS will be downloaded. By setting [Environment variables](https://nodkz.github.io/mongodb-memory-server/docs/api/config-options) you are able to specify which version and binary will be downloaded:
 
 ```sh
 export MONGOMS_DOWNLOAD_URL=https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.8.tgz
@@ -103,24 +103,18 @@ export MONGOMS_VERSION=4.2.8
 ```js
 import { MongoMemoryServer } from 'mongodb-memory-server';
 
-const mongod = new MongoMemoryServer();
+const mongod = await MongoMemoryServer.create();
 
-const uri = await mongod.getUri();
-const port = await mongod.getPort();
-const dbPath = await mongod.getDbPath();
-const dbName = await mongod.getDbName();
+const uri = mongod.getUri();
 
 // some code
 //   ... where you may use `uri` for as a connection string for mongodb or mongoose
 
-// you may check instance status, after you got `uri` it must be `true`
-mongod.getInstanceInfo(); // return Object with instance data
+// you may get instance info
+console.log(mongod.instanceInfo); // return Object with instance data
 
 // you may stop mongod manually
 await mongod.stop();
-
-// when mongod killed, it's running status should be `false`
-mongod.getInstanceInfo();
 
 // even you forget to stop `mongod` when you exit from script
 // special childProcess killer will shutdown it for you
@@ -131,7 +125,7 @@ mongod.getInstanceInfo();
 All options are optional.
 
 ```js
-const mongod = new MongoMemoryServer({
+const mongod = await MongoMemoryServer.create({
   instance: {
     port?: number, // by default choose any free port
     ip?: string, // by default '127.0.0.1', for binding to all IP addresses set it to `::,0.0.0.0`,

--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -721,7 +721,18 @@ export default MongoMemoryServer;
  * @param val this.instanceInfo
  */
 function assertionInstanceInfo(val: unknown): asserts val is MongoInstanceData {
-  assertion(!isNullOrUndefined(val), new Error('"instanceInfo" is undefined'));
+  const solution = `
+    Starting from mongodb-memory-server@7.0.0 was changed method of server creation:
+    
+    In v6 it was:
+      const mongoServer = new MongoMemoryServer();
+      const mongoUri = await mongoServer.getUri(true);
+
+    Starting from v7 it became:
+      const mongoServer = await MongoMemoryServer.create();
+      const mongoUri = mongoServer.getUri();
+  `;
+  assertion(!isNullOrUndefined(val), new Error('"instanceInfo" is undefined' + '\n' + solution));
 }
 
 /**


### PR DESCRIPTION
I've just migrated `graphql-compose-mongoose@7.1.0` to a new version and met with the following problems:
- got unfriendly `"instanceInfo" is undefined` error message which does not explain what happens and what to do. In this PR I tried to provide users a little bit more information on how to resolve this problem.
- I found that README.md contains old examples for v6. I've changed docs for the first example. But I didn't know what to do with ReplicaSet.

@hasezoey can you review my changes? And please fix other parts of README otherwise users blow up with issues. Tnx.