### PR TITLE
fix(errors): EACCES: do not throw on EACCES

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/utils.test.ts
@@ -31,7 +31,7 @@ describe('utils', () => {
   });
 
   describe('statPath', () => {
-    it('should throw an error if code is not "ENOENT"', async () => {
+    it('should throw an error if code is not "ENOENT" or "EACCES"', async () => {
       const retError = new Error();
       // @ts-expect-error because there is no FSError, or an error with an "code" property - but still being used
       retError.code = 'EPERM';
@@ -97,7 +97,20 @@ describe('utils', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('should throw an error if error is not "ENOENT"', async () => {
+    it('should return "undefined" if "EACCES"', async () => {
+      const retError = new Error();
+      // @ts-expect-error because there is no FSError, or an error with an "code" property - but still being used
+      retError.code = 'EACCES';
+      jest.spyOn(fspromises, 'readFile').mockRejectedValueOnce(retError);
+
+      await expect(
+        utils.tryReleaseFile('/some/path', () => {
+          fail('This Function should never run');
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw an error if error is not "ENOENT" or "EACCES"', async () => {
       const retError = new Error();
       // @ts-expect-error because there is no FSError, or an error with an "code" property - but still being used
       retError.code = 'EPERM';

--- a/packages/mongodb-memory-server-core/src/util/utils.ts
+++ b/packages/mongodb-memory-server-core/src/util/utils.ts
@@ -145,15 +145,16 @@ export function authDefault(opts: AutomaticAuth): Required<AutomaticAuth> {
 }
 
 /**
- * Run "fs.promises.stat", but return "undefined" if error is "ENOENT"
+ * Run "fs.promises.stat", but return "undefined" if error is "ENOENT" or "EACCES"
  * follows symlinks
  * @param path The Path to Stat
- * @throws if the error is not "ENOENT"
+ * @throws if the error is not "ENOENT" or "EACCES"
  */
 export async function statPath(path: string): Promise<Stats | undefined> {
   return fspromises.stat(path).catch((err) => {
-    if (err.code === 'ENOENT') {
-      return undefined; // catch the error if the directory dosnt exist, without throwing an error
+    // catch the error if the directory doesn't exist or permission is denied, without throwing an error
+    if (['ENOENT', 'EACCES'].includes(err.code)) {
+      return undefined;
     }
 
     throw err;
@@ -184,7 +185,7 @@ export async function tryReleaseFile(
 
     return parser(output.toString());
   } catch (err) {
-    if (err.code !== 'ENOENT') {
+    if (!['ENOENT', 'EACCES'].includes(err.code)) {
       throw err;
     }
 


### PR DESCRIPTION
Hi! 👋 Thanks heaps for creating and maintaing such a useful library! 🙇

I noticed that when the Node.js process doesn't have permission to access the OS cache directory, an `EACCES` error is thrown and the process crashes. The following error happens to us in our CI environment:

```bash
EACCES: permission denied, stat '/root/.cache/mongodb-binaries/mongod-x64-ubuntu-4.0.25'
```

This pull request updates the handling of `EACCES` errors to match the way `ENOENT` errors are handled: returning `undefined` from `statPath()` without throwing an error. The result is that a MongoDB binary should be able to be installed to a local directory when access to the OS cache directory is restricted. The JSDoc comment was also updated and a test for this specific case was added.