### PR TITLE
Docs: Fix broken mocha integration example

### DIFF
--- a/docs/guides/integration-examples.md
+++ b/docs/guides/integration-examples.md
@@ -96,8 +96,8 @@ let mongoServer;
 const opts = { useMongoClient: true }; // remove this option if you use mongoose 5 and above
 
 before(async () => {
-  mongoServer = new MongoMemoryServer();
-  const mongoUri = await mongoServer.getUri();
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
   await mongoose.connect(mongoUri, opts);
 });
 


### PR DESCRIPTION
The existing mocha example uses what looks like syntax from version 6, which does not work in current version. 

## Changes
- update the `before` hook in the mocha integration example to work in current version.

