### PR TITLE
Mongo Replica set - Add replicaMemberConfig to replica instance

### DIFF
--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -272,6 +272,9 @@ export class MongoMemoryReplSet extends EventEmitter implements ManagerAdvanced 
     if (baseOpts.storageEngine) {
       opts.storageEngine = baseOpts.storageEngine;
     }
+    if (baseOpts.replicaMemberConfig) {
+      opts.replicaMemberConfig = baseOpts.replicaMemberConfig;
+    }
 
     log('getInstanceOpts: instance opts:', opts);
 
@@ -506,7 +509,11 @@ export class MongoMemoryReplSet extends EventEmitter implements ManagerAdvanced 
     try {
       let adminDb = con.db('admin');
 
-      const members = uris.map((uri, index) => ({ _id: index, host: getHost(uri) }));
+      const members = uris.map((uri, index) => ({
+        _id: index,
+        host: getHost(uri),
+        ...(this.servers[index].opts.instance?.replicaMemberConfig || {}), // Overwrite replica member config
+      }));
       const rsConfig = {
         _id: this._replSetOpts.name,
         members,

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryReplSet.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryReplSet.test.ts
@@ -148,7 +148,7 @@ describe('single server replset', () => {
         {
           args: ['--quiet'],
           replicaMemberConfig: {
-            arbiterOnly: true,
+            priority: 2,
           },
         },
       ],
@@ -158,7 +158,7 @@ describe('single server replset', () => {
     expect(
       replSet.servers[0].opts.instance!.args!.findIndex((x) => x === '--quiet') > -1
     ).toBeTruthy();
-    expect(replSet.servers[0].opts.instance?.replicaMemberConfig?.arbiterOnly).toBe(true);
+    expect(replSet.servers[0].opts.instance?.replicaMemberConfig?.priority).toBe(2);
 
     await replSet.stop();
   });

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryReplSet.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryReplSet.test.ts
@@ -143,12 +143,22 @@ describe('single server replset', () => {
   });
 
   it('start an replset with instanceOpts', async () => {
-    const replSet = new MongoMemoryReplSet({ instanceOpts: [{ args: ['--quiet'] }] });
+    const replSet = new MongoMemoryReplSet({
+      instanceOpts: [
+        {
+          args: ['--quiet'],
+          replicaMemberConfig: {
+            arbiterOnly: true,
+          },
+        },
+      ],
+    });
     await replSet.start();
 
     expect(
       replSet.servers[0].opts.instance!.args!.findIndex((x) => x === '--quiet') > -1
     ).toBeTruthy();
+    expect(replSet.servers[0].opts.instance?.replicaMemberConfig?.arbiterOnly).toBe(true);
 
     await replSet.stop();
   });

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -16,14 +16,68 @@ const log = debug('MongoMS:MongoInstance');
 
 export type StorageEngine = 'devnull' | 'ephemeralForTest' | 'mmapv1' | 'wiredTiger';
 
-// Ref: https://docs.mongodb.com/manual/reference/replica-configuration/#replica-set-configuration-document-example
+/**
+ * Overwrite replica member-specific configuration
+ *
+ * @see {@link https://docs.mongodb.com/manual/reference/replica-configuration/#replica-set-configuration-document-example}
+ *
+ * @example
+ * ```ts
+ * {
+ *   priority: 2,
+ *   buildIndexes: false,
+ *   votes: 2,
+ * }
+ * ```
+ */
 export interface ReplicaMemberConfig {
+  /**
+   * A boolean that identifies an arbiter.
+   * @defaultValue `false` - A value of `true` indicates that the member is an arbiter.
+   */
   arbiterOnly?: boolean;
+
+  /**
+   * A boolean that indicates whether the mongod builds indexes on this member.
+   * You can only set this value when adding a member to a replica set.
+   * @defaultValue `true`
+   */
   buildIndexes?: boolean;
+
+  /**
+   * The replica set hides this instance and does not include the member in the output of `db.hello()` or `hello`.
+   * @defaultValue `true`
+   */
   hidden?: boolean;
+
+  /**
+   * A number that indicates the relative eligibility of a member to become a primary.
+   * Specify higher values to make a member more eligible to become primary, and lower values to make the member less eligible.
+   * @defaultValue 1.0 for primary/secondary; 0 for arbiters.
+   */
   priority?: number;
+
+  /**
+   * A tags document contains user-defined tag field and value pairs for the replica set member.
+   * @defaultValue `null`
+   * @example
+   * ```ts
+   * { "<tag1>": "<string1>", "<tag2>": "<string2>",... }
+   * ```
+   */
   tags?: any;
+
+  /**
+   * The number of seconds "behind" the primary that this replica set member should "lag".
+   * @defaultValue 0
+   */
   secondaryDelaySecs?: number;
+
+  /**
+   * The number of votes a server will cast in a replica set election.
+   * The number of votes each member has is either 1 or 0, and arbiters always have exactly 1 vote.
+   * @defaultValue 1
+   */
   votes?: number;
 }
 

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -16,11 +16,23 @@ const log = debug('MongoMS:MongoInstance');
 
 export type StorageEngine = 'devnull' | 'ephemeralForTest' | 'mmapv1' | 'wiredTiger';
 
+// Ref: https://docs.mongodb.com/manual/reference/replica-configuration/#replica-set-configuration-document-example
+export interface ReplicaMemberConfig {
+  arbiterOnly?: boolean;
+  buildIndexes?: boolean;
+  hidden?: boolean;
+  priority?: number;
+  tags?: any;
+  secondaryDelaySecs?: number;
+  votes?: number;
+}
+
 export interface MongoMemoryInstanceOptsBase {
   args?: string[];
   port?: number;
   dbPath?: string;
   storageEngine?: StorageEngine;
+  replicaMemberConfig?: ReplicaMemberConfig;
 }
 
 export interface MongoMemoryInstanceOpts extends MongoMemoryInstanceOptsBase {

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -69,7 +69,7 @@ export interface ReplicaMemberConfig {
 
   /**
    * Mongodb 4.x only - The number of seconds "behind" the primary that this replica set member should "lag".
-   * @deprecated For mongodb 5.x, use `secondaryDelaySecs` instead.
+   * For mongodb 5.x, use `secondaryDelaySecs` instead.
    * @see {@link https://docs.mongodb.com/v4.4/tutorial/configure-a-delayed-replica-set-member/}
    * @defaultValue 0
    */

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -68,7 +68,15 @@ export interface ReplicaMemberConfig {
   tags?: any;
 
   /**
-   * The number of seconds "behind" the primary that this replica set member should "lag".
+   * Mongodb 4.x only - The number of seconds "behind" the primary that this replica set member should "lag".
+   * @deprecated For mongodb 5.x, use `secondaryDelaySecs` instead.
+   * @see {@link https://docs.mongodb.com/v4.4/tutorial/configure-a-delayed-replica-set-member/}
+   * @defaultValue 0
+   */
+  slaveDelay?: number;
+
+  /**
+   * Mongodb 5.x only - The number of seconds "behind" the primary that this replica set member should "lag".
    * @defaultValue 0
    */
   secondaryDelaySecs?: number;


### PR DESCRIPTION
## Replica Set Configuration - Add member config
Ref: https://docs.mongodb.com/manual/reference/replica-configuration/#replica-set-configuration-document-example

Sample code:
```javascript
const replSet = new MongoMemoryReplSet({
  instanceOpts: [
    {
      args: ["--quiet"],
      replicaMemberConfig: {
        arbiterOnly: true,
      },
    },
  ],
});

```

## Related Issues

- fixes #209 