### PR TITLE
Fix dbName default doc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ const mongod = new MongoMemoryServer({
   instance: {
     port?: number, // by default choose any free port
     ip?: string, // by default '127.0.0.1', for binding to all IP addresses set it to `::,0.0.0.0`,
-    dbName?: string, // by default return empty string
+    dbName?: string, // by default '' (empty string)
     dbPath?: string, // by default create in temp directory
     storageEngine?: string, // by default `ephemeralForTest`, available engines: [ 'ephemeralForTest', 'wiredTiger' ]
     replSet?: string, // by default no replica set, replica set name

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ const mongod = new MongoMemoryServer({
   instance: {
     port?: number, // by default choose any free port
     ip?: string, // by default '127.0.0.1', for binding to all IP addresses set it to `::,0.0.0.0`,
-    dbName?: string, // by default generate random dbName
+    dbName?: string, // by default return empty string
     dbPath?: string, // by default create in temp directory
     storageEngine?: string, // by default `ephemeralForTest`, available engines: [ 'ephemeralForTest', 'wiredTiger' ]
     replSet?: string, // by default no replica set, replica set name


### PR DESCRIPTION
<!--
## Make sure you have done these steps

- Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

[Noticed that it's now an empty string.](https://github.com/nodkz/mongodb-memory-server/blob/394ca2b35f9ca0636bf3e9c71788a142955ea000/packages/mongodb-memory-server-core/src/util/utils.ts#L16) I was using the `dbName` value in my tests and upgrading to >7.0 broke my suite. This should help others when upgrading past 7.0


