### PR TITLE
fix(MongoMemoryServer): invert `isNew` for dbPaths

### DIFF
--- a/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryServer.ts
@@ -362,7 +362,7 @@ export class MongoMemoryServer extends EventEmitter implements ManagerAdvanced {
         );
         const files = await fspromises.readdir(data.dbPath);
 
-        isNew = files.length > 0; // if there already files in the directory, assume that the database is not new
+        isNew = files.length === 0; // if there are no files in the directory, assume that the database is new
       }
     } else {
       isNew = false;

--- a/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
+++ b/packages/mongodb-memory-server-core/src/__tests__/MongoMemoryServer.test.ts
@@ -11,6 +11,8 @@ import * as utils from '../util/utils';
 import * as semver from 'semver';
 import { EnsureInstanceError, StateError } from '../util/errors';
 import { assertIsError } from './testUtils/test_utils';
+import { promises as fspromises } from 'fs';
+import * as path from 'path';
 
 tmp.setGracefulCleanup();
 jest.setTimeout(100000); // 10s
@@ -606,6 +608,76 @@ describe('MongoMemoryServer', () => {
         assertIsError(err);
         expect(err.message).toMatchSnapshot();
       }
+    });
+  });
+
+  describe('getStartOptions()', () => {
+    it('should create a tmpdir if "dbPath" is not set', async () => {
+      // somehow, jest cannot redefine function "dirSync", so this is disabled
+      // const tmpSpy = jest.spyOn(tmp, 'dirSync');
+      const mongoServer = new MongoMemoryServer({});
+
+      // @ts-expect-error "getStartOptions" is protected
+      const options = await mongoServer.getStartOptions();
+
+      // see comment above
+      // expect(tmpSpy).toHaveBeenCalledTimes(1);
+      expect(options.data.tmpDir).toBeDefined();
+      // jest "expect" do not act as typescript typeguards
+      utils.assertion(
+        !utils.isNullOrUndefined(options.data.dbPath),
+        new Error('Expected "options.data.dbPath" to be defined')
+      );
+      expect(await utils.pathExists(options.data.dbPath)).toEqual(true);
+    });
+
+    it('should resolve "isNew" to "true" and set "createAuth" to "true" when dbPath is set, but empty', async () => {
+      const readdirSpy = jest.spyOn(fspromises, 'readdir');
+      const tmpDbPath = tmp.dirSync({ prefix: 'mongo-mem-getStartOptions1-', unsafeCleanup: true });
+
+      const mongoServer = new MongoMemoryServer({
+        instance: { dbPath: tmpDbPath.name },
+        auth: {},
+      });
+
+      // @ts-expect-error "getStartOptions" is protected
+      const options = await mongoServer.getStartOptions();
+
+      expect(options.data.tmpDir).toBeUndefined();
+      utils.assertion(
+        !utils.isNullOrUndefined(options.data.dbPath),
+        new Error('Expected "options.data.dbPath" to be defined')
+      );
+      expect(await utils.pathExists(options.data.dbPath)).toEqual(true);
+      expect(options.data.dbPath).toEqual(tmpDbPath.name);
+      expect(readdirSpy).toHaveBeenCalledTimes(1);
+      expect(options.createAuth).toEqual(true);
+    });
+
+    it('should resolve "isNew" to "false" and set "createAuth" to "false" when dbPath is set, but not empty', async () => {
+      const readdirSpy = jest.spyOn(fspromises, 'readdir');
+      const tmpDbPath = tmp.dirSync({ prefix: 'mongo-mem-getStartOptions1-', unsafeCleanup: true });
+
+      // create dummy file, to make the directory non-empty
+      await fspromises.writeFile(path.resolve(tmpDbPath.name, 'testfile'), '');
+
+      const mongoServer = new MongoMemoryServer({
+        instance: { dbPath: tmpDbPath.name },
+        auth: {},
+      });
+
+      // @ts-expect-error "getStartOptions" is protected
+      const options = await mongoServer.getStartOptions();
+
+      expect(options.data.tmpDir).toBeUndefined();
+      utils.assertion(
+        !utils.isNullOrUndefined(options.data.dbPath),
+        new Error('Expected "options.data.dbPath" to be defined')
+      );
+      expect(await utils.pathExists(options.data.dbPath)).toEqual(true);
+      expect(options.data.dbPath).toEqual(tmpDbPath.name);
+      expect(readdirSpy).toHaveBeenCalledTimes(1);
+      expect(options.createAuth).toEqual(false);
     });
   });
 


### PR DESCRIPTION
This closes #573: a folder without any files indicates a new database.

## Related Issues

- #573 