### PR TITLE
fix(MongoBinaryDownloadUrl.ts): Add current openSUSE Leap release version

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -330,7 +330,7 @@ export class MongoBinaryDownloadUrl implements MongoBinaryDownloadUrlOpts {
    * @param os LinuxOS Object
    */
   getSuseVersionString(os: LinuxOS): string {
-    const releaseMatch: RegExpMatchArray | null = os.release.match(/(^11|^12)/);
+    const releaseMatch: RegExpMatchArray | null = os.release.match(/(^11|^12|^15)/);
 
     return releaseMatch ? `suse${releaseMatch[0]}` : '';
   }


### PR DESCRIPTION
Add current openSUSE Leap release version (15) to the regular
expression. The change should fix the creation of the DownloadURL for
openSUSE Leap 15.x.

Only tested on openSUSE Leap 15.3.

Signed-off-by: Jürgen Löhel <juergen@loehel.de>
