### PR TITLE
Add info in README for slim Docker node images

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ And one of those (on Linux):
 - having an `/etc/*-release` file that is compliant to the [OS-Release Spec](https://www.freedesktop.org/software/systemd/man/os-release.html) (and does not include `lsb`)
 - manually specify which version & system should be used
 
+On Linux, you will also need `libcurl4`. This will probably only be an issue on "slim" Docker images.
+
 ### Choose the Correct Package
 
 [Choose the right package for the task](https://nodkz.github.io/mongodb-memory-server/docs/guides/quick-start-guide#choose-the-right-package)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ And one of those (on Linux):
 - having an `/etc/*-release` file that is compliant to the [OS-Release Spec](https://www.freedesktop.org/software/systemd/man/os-release.html) (and does not include `lsb`)
 - manually specify which version & system should be used
 
-On Linux, you will also need `libcurl4`. This will probably only be an issue on "slim" Docker images.
+On Linux, you will also need `libcurl4` (or `libcurl3` on some older distro versions). This will probably only be an issue on "slim" Docker images.
 
 ### Choose the Correct Package
 

--- a/docs/guides/known-issues.md
+++ b/docs/guides/known-issues.md
@@ -24,8 +24,7 @@ Workaround:
 
 ## libcurl on slim Docker images
 
-Docker images of the "slim" variety often don't have `libcurl` installed,
-such as [the official Node.js image](https://hub.docker.com/_/node) or [sitespeed.io node](https://hub.docker.com/r/sitespeedio/node).
+Docker images of the "slim" variety often don't have `libcurl` installed, such as [the official Node.js image](https://hub.docker.com/_/node) or [sitespeed.io node](https://hub.docker.com/r/sitespeedio/node).  
 If you don't install it manually, then `mongodb-memory-server` will not start up in your container, with the following exception message:
 
 > Instance Exited before being ready and without throwing an error!
@@ -33,5 +32,5 @@ If you don't install it manually, then `mongodb-memory-server` will not start up
 This can easily be resolved by installing it in your image:
 
 ```sh
-$ apt-get install libcurl4
+apt-get install libcurl4
 ```

--- a/docs/guides/known-issues.md
+++ b/docs/guides/known-issues.md
@@ -21,3 +21,17 @@ Workaround:
 
 - Use a SystemBinary with [`SYSTEM_BINARY`](../api/config-options.md#SYSTEM_BINARY)
 - Do not use AlpineLinux
+
+## libcurl on slim Docker images
+
+Docker images of the "slim" variety often don't have `libcurl` installed,
+such as [the official Node.js image](https://hub.docker.com/_/node) or [sitespeed.io node](https://hub.docker.com/r/sitespeedio/node).
+If you don't install it manually, then `mongodb-memory-server` will not start up in your container, with the following exception message:
+
+> Instance Exited before being ready and without throwing an error!
+
+This can easily be resolved by installing it in your image:
+
+```sh
+$ apt-get install libcurl4
+```

--- a/docs/guides/known-issues.md
+++ b/docs/guides/known-issues.md
@@ -24,7 +24,7 @@ Workaround:
 
 ## libcurl on slim Docker images
 
-Docker images of the "slim" variety often don't have `libcurl` installed, such as [the official Node.js image](https://hub.docker.com/_/node) or [sitespeed.io node](https://hub.docker.com/r/sitespeedio/node).  
+Docker images of the "slim" variety often don't have `libcurl` installed, such as [the official "slim" Node.js image](https://hub.docker.com/_/node) or [sitespeed.io node](https://hub.docker.com/r/sitespeedio/node).  
 If you don't install it manually, then `mongodb-memory-server` will not start up in your container, with the following exception message:
 
 > Instance Exited before being ready and without throwing an error!

--- a/docs/guides/quick-start-guide.md
+++ b/docs/guides/quick-start-guide.md
@@ -17,6 +17,8 @@ When on Linux, one of the following are required:
 - having an `/etc/*-release` file that is compliant to the [OS-Release Spec](https://www.freedesktop.org/software/systemd/man/os-release.html) (and does not include `lsb`)
 - manually specify which version & system should be used
 
+On Linux, you will also need `libcurl`. This will probably only be an issue on "slim" Docker images.
+
 ## Choose the right package
 
 There are multiple packages for this project, here are the differences:

--- a/docs/guides/quick-start-guide.md
+++ b/docs/guides/quick-start-guide.md
@@ -17,7 +17,7 @@ When on Linux, one of the following are required:
 - having an `/etc/*-release` file that is compliant to the [OS-Release Spec](https://www.freedesktop.org/software/systemd/man/os-release.html) (and does not include `lsb`)
 - manually specify which version & system should be used
 
-On Linux, you will also need `libcurl`. This will probably only be an issue on "slim" Docker images.
+On Linux, you will also need `libcurl` (or `libcurl3` on some older distro versions). This will probably only be an issue on "slim" Docker images.
 
 ## Choose the right package
 


### PR DESCRIPTION
I encountered this issue while trying to run `mongodb-memory-server` on a Docker image based on `node:16.9.1-slim`. 
