### PR TITLE
fix(MongoBinary): Fix mongo binary matching regex

### DIFF
--- a/docs/api/config-options.md
+++ b/docs/api/config-options.md
@@ -53,9 +53,11 @@ Search for what version is used:
 - [`windows`](https://www.mongodb.org/dl/win32)
 - [`linux`](https://dl.mongodb.org/dl/linux)
 
-When using `SYSTEM_BINARY` and `SYSTEM_BINARY_VERSION_CHECK`, ONLY the major, minor, and patch versions of the system binary will be compared against the desired binary.
+:::note
+When using [`SYSTEM_BINARY`](#system_binary) and [`SYSTEM_BINARY_VERSION_CHECK`](#system_binary_version_check), ONLY the major, minor, and patch versions of the system binary will be compared against the desired binary.
 
 That is, a system binary version of `4.2.19-11-ge2f2736a` will match a mongodb required version of `4.2.19`. DO NOT set the mongodb required version to the full `4.2.19-11-ge2f2736a` version as the check which examines the binary version will strip the additional tags.
+:::
 
 ### DEBUG
 

--- a/docs/api/config-options.md
+++ b/docs/api/config-options.md
@@ -53,6 +53,10 @@ Search for what version is used:
 - [`windows`](https://www.mongodb.org/dl/win32)
 - [`linux`](https://dl.mongodb.org/dl/linux)
 
+When using `SYSTEM_BINARY` and `SYSTEM_BINARY_VERSION_CHECK`, ONLY the major, minor, and patch versions of the system binary will be compared against the desired binary.
+
+That is, a system binary version of `4.2.19-11-ge2f2736a` will match a mongodb required version of `4.2.19`. DO NOT set the mongodb required version to the full `4.2.19-11-ge2f2736a` version as the check which examines the binary version will strip the additional tags.
+
 ### DEBUG
 
 Option `DEBUG` is used to enable Debug Output

--- a/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinary.ts
@@ -92,8 +92,8 @@ export class MongoBinary {
         log(`getPath: Spawning binaryPath "${binaryPath}" to get version`);
         const spawnOutput = spawnSync(binaryPath, ['--version'])
           .stdout.toString()
-          // this regex is to match the first line of the "mongod --version" output "db version v4.0.25"
-          .match(/^\s*db\s+version\s+v?(\d+\.\d+\.\d+)\s*$/im);
+          // this regex is to match the first line of the "mongod --version" output "db version v4.0.25" OR "db version v4.2.19-11-ge2f2736"
+          .match(/^\s*db\s+version\s+v?(\d+\.\d+\.\d+)(-\d*)?(-[a-zA-Z0-9].*)?\s*$/im);
 
         assertion(
           !isNullOrUndefined(spawnOutput),

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinary.test.ts
@@ -138,6 +138,32 @@ build environment:
         expect(output).toBe(sysBinaryPath);
       });
 
+      it('should return and check an SystemBinary and match even if binary has patch version', async () => {
+        // Output taken from mongodb x64 for "debian" version "4.2.19-11-ge2f2736"
+        // DO NOT INDENT THE TEXT
+        jest.spyOn(childProcess, 'spawnSync').mockReturnValue(
+          // @ts-expect-error Because "Buffer" is missing values from type, but they are not used in code, so its fine
+          {
+            stdout: Buffer.from(`db version v4.2.19-11-ge2f2736
+git version: e2f27369cdfb8c417b026afb323c810226417206
+OpenSSL version: OpenSSL 1.1.1n  15 Mar 2022
+allocator: tcmalloc
+modules: none
+build environment:
+    distmod: debian10
+    distarch: x86_64
+    target_arch: x86_64`),
+          }
+        );
+        process.env[envName(ResolveConfigVariables.VERSION)] = '4.2.19'; // set it explicitly to that version to test matching versions
+        process.env[envName(ResolveConfigVariables.SYSTEM_BINARY)] = sysBinaryPath;
+
+        const output = await MongoBinary.getPath();
+        expect(childProcess.spawnSync).toHaveBeenCalledTimes(1);
+        expect(MongoBinary.download).not.toHaveBeenCalled();
+        expect(output).toBe(sysBinaryPath);
+      });
+
       it('should return and check an SYSTEM_BINARY and warn version conflict', async () => {
         jest.spyOn(console, 'warn').mockImplementation(() => void 0);
         // Output taken from mongodb x64 for "ubuntu" version "4.0.25"


### PR DESCRIPTION
Fix regex that tests the local mongo binary version so that it can
handle versions that include patches and/or other tags.

## Related Issues
<!--Remove this part if not applicable-->

- fixes #624
