### PR TITLE
fix(MongoMemoryReplSet): pass-through option "launchTimeout" correctly

### DIFF
--- a/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
+++ b/packages/mongodb-memory-server-core/src/MongoMemoryReplSet.ts
@@ -322,6 +322,9 @@ export class MongoMemoryReplSet extends EventEmitter implements ManagerAdvanced 
     if (baseOpts.replicaMemberConfig) {
       opts.replicaMemberConfig = baseOpts.replicaMemberConfig;
     }
+    if (baseOpts.launchTimeout) {
+      opts.launchTimeout = baseOpts.launchTimeout;
+    }
 
     log('getInstanceOpts: instance opts:', opts);
 

--- a/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoInstance.ts
@@ -132,6 +132,12 @@ export interface MongoMemoryInstanceOptsBase {
    * Only has a effect when started with "MongoMemoryReplSet"
    */
   replicaMemberConfig?: ReplicaMemberConfig;
+  /**
+   * Define a custom timeout for when out of some reason the binary cannot get started correctly
+   * Time in MS
+   * @default 10000 10 seconds
+   */
+  launchTimeout?: number;
 }
 
 export interface MongoMemoryInstanceOpts extends MongoMemoryInstanceOptsBase {
@@ -166,12 +172,6 @@ export interface MongoMemoryInstanceOpts extends MongoMemoryInstanceOptsBase {
    * @default undefined
    */
   keyfileLocation?: string;
-  /**
-   * Define a custom timeout for when out of some reason the binary cannot get started correctly
-   * Time in MS
-   * @default 10000 10 seconds
-   */
-  launchTimeout?: number;
 }
 
 export enum MongoInstanceEvents {


### PR DESCRIPTION
The launchTimeout option if specified in instanceOpts for MongoMemoryReplSet doesn't get passed into the eventual options for each underlying MongoMemoryServer. This change modifies the base opts type to include launchTimeout as a common instance option. 

I have run the automated tests, but I am not sure exactly what else needs testing.