### PR TITLE
Widen dependency range for mongodb

### DIFF
--- a/packages/mongodb-memory-server-core/package.json
+++ b/packages/mongodb-memory-server-core/package.json
@@ -50,7 +50,7 @@
     "get-port": "^5.1.1",
     "https-proxy-agent": "^5.0.1",
     "md5-file": "^5.0.0",
-    "mongodb": "~4.11.0",
+    "mongodb": "^4.11.0",
     "new-find-package-json": "^2.0.0",
     "semver": "^7.3.8",
     "tar-stream": "^2.1.4",


### PR DESCRIPTION
The current dependency only allows mongodb >=4.11.0  and <4.12.0 but 4.12 is out and should be compatible.

When libraries restrict the dependency ranges it can cause issues beyond simply having multiple copies of the library installed, but also instrumentation / monitoring libraries might instrument the "wrong" copy of mongodb, as is the case for us.
