### PR TITLE
feat(getos): allow to override the release file

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/getos/index.ts
+++ b/packages/mongodb-memory-server-core/src/util/getos/index.ts
@@ -70,10 +70,17 @@ export async function getOS(): Promise<AnyOS> {
 /** Function to outsource Linux Information Parsing */
 async function getLinuxInformation(): Promise<LinuxOS> {
   // Structure of this function:
-  // 1. get upstream release, if possible
-  // 2. get os release (etc) because it has an "id_like"
-  // 3. get os release (usr) because it has an "id_like"
-  // 4. get lsb-release (etc) as fallback
+  // 1. get os release from environment variable, if set
+  // 2. get upstream release, if possible
+  // 3. get os release (etc) because it has an "id_like"
+  // 4. get os release (usr) because it has an "id_like"
+  // 5. get lsb-release (etc) as fallback
+  const envOsRelease = await tryReleaseFile(process.env.LSB_OS_RELEASE, parseOS);
+  if (isValidOs(envOsRelease)) {
+    log('getLinuxInformation: Using envOsRelease');
+
+    return envOsRelease;
+  }
 
   const upstreamLSB = await tryReleaseFile('/etc/upstream-release/lsb-release', parseLSB);
 


### PR DESCRIPTION
The lsb_release program upstream allows to use the LSB_OS_RELEASE environment variable to override the release file to consider, it would be nice to support this here.

For instance, we plan to move away from /etc/upstream-release/lsb-release in elementary OS to /usr/lib/upstream-os-release

Note that the lsb-release file (and its format) is now legacy and isn't even used by lsb_release itself.

## Related Issues

- #735

Note that this is my first time dealing with TypeScript so any feedback welcome :slightly_smiling_face: 
