### PR TITLE
download correct package for arch

### DIFF
--- a/docs/guides/supported-systems.md
+++ b/docs/guides/supported-systems.md
@@ -144,7 +144,7 @@ Default version is none
 <span class="badge badge--danger">Unsupported</span> <span class="badge badge--secondary">Working</span>
 
 There are no official mongodb builds for Arch Distributions, but the `ubuntu` binaries work on most Arch systems, so they are used.<br/>
-Currently Mapping to: `ubuntu2004`
+Currently Mapping to: `ubuntu2204`
 
 :::note
 Because Arch* dosnt base on ubuntu, there is no specific ubuntu version associated with an arch version, so it defaults to highest supported `ubuntu` version

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -203,13 +203,13 @@ export class MongoBinaryDownloadUrl implements MongoBinaryDownloadUrlOpts {
       // Match "arch", "archlinux", "manjaro", "manjarolinux", "arco", "arcolinux"
     } else if (regexHelper(/(arch|manjaro|arco)(?:linux)?$/i, os)) {
       console.warn(
-        `There is no official build of MongoDB for ArchLinux (${os.dist}). Falling back to Ubuntu 20.04 release.`
+        `There is no official build of MongoDB for ArchLinux (${os.dist}). Falling back to Ubuntu 22.04 release.`
       );
 
       return this.getUbuntuVersionString({
         os: 'linux',
         dist: 'Ubuntu Linux',
-        release: '20.04',
+        release: '22.04',
       });
     } else if (regexHelper(/gentoo/i, os)) {
       // it seems like debian binaries work for gentoo too (at least most), see https://github.com/nodkz/mongodb-memory-server/issues/639

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -1684,7 +1684,7 @@ describe('MongoBinaryDownloadUrl', () => {
   });
 
   describe('getLinuxOSVersionString()', () => {
-    it('should give an warning about "alpine"', () => {
+    it('should give a warning about "alpine"', () => {
       jest.spyOn(console, 'warn').mockImplementation(() => void 0);
       const du = new MongoBinaryDownloadUrl({
         platform: 'linux',
@@ -1704,7 +1704,7 @@ describe('MongoBinaryDownloadUrl', () => {
       expect(ret).toBe('');
     });
 
-    it('should give an warning about "unknown"', () => {
+    it('should give a warning about "unknown"', () => {
       jest.spyOn(console, 'warn').mockImplementation(() => void 0);
       const du = new MongoBinaryDownloadUrl({
         platform: 'linux',
@@ -1722,6 +1722,24 @@ describe('MongoBinaryDownloadUrl', () => {
       expect(console.warn).toHaveBeenCalledTimes(2);
       expect(du.getLegacyVersionString).toHaveBeenCalledTimes(1);
       expect(ret).toBe('');
+    });
+
+    it('should give a warning about "arch"', () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => void 0);
+      const du = new MongoBinaryDownloadUrl({
+        platform: 'linux',
+        arch: 'x64',
+        version: '3.6.3',
+        os: {
+          os: 'linux',
+          dist: 'archlinux',
+          release: '0',
+          codename: 'archlinux',
+        },
+      });
+      const ret = du.getLinuxOSVersionString(du.os as LinuxOS);
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(ret).toBe('ubuntu1604');
     });
   });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -659,6 +659,46 @@ describe('MongoBinaryDownloadUrl', () => {
           expect(console.warn).toHaveBeenCalledTimes(1);
         });
 
+        it('for arch for 5.0.0', async () => {
+          jest.spyOn(console, 'warn').mockImplementation(() => void 0);
+
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: '5.0.0',
+            os: {
+              os: 'linux',
+              dist: 'Arch',
+              release: 'rolling',
+              id_like: ['arch'],
+            },
+          });
+          expect(await du.getDownloadUrl()).toBe(
+            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.0.tgz'
+          );
+          expect(console.warn).toHaveBeenCalledTimes(1);
+        });
+
+        it('for arch for 6.0.4', async () => {
+          jest.spyOn(console, 'warn').mockImplementation(() => void 0);
+
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: '6.0.4',
+            os: {
+              os: 'linux',
+              dist: 'Arch',
+              release: 'rolling',
+              id_like: ['arch'],
+            },
+          });
+          expect(await du.getDownloadUrl()).toBe(
+            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.4.tgz'
+          );
+          expect(console.warn).toHaveBeenCalledTimes(1);
+        });
+
         it('for manjaro for 4.4.2', async () => {
           jest.spyOn(console, 'warn').mockImplementation(() => void 0);
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -637,6 +637,69 @@ describe('MongoBinaryDownloadUrl', () => {
         });
       });
 
+      // for arch and arch based systems (no specific extra mapping)
+      describe('for arch', () => {
+        it('for arch for 4.4.2', async () => {
+          jest.spyOn(console, 'warn').mockImplementation(() => void 0);
+
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: '4.4.2',
+            os: {
+              os: 'linux',
+              dist: 'Arch',
+              release: 'rolling',
+              id_like: ['arch'],
+            },
+          });
+          expect(await du.getDownloadUrl()).toBe(
+            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.2.tgz'
+          );
+          expect(console.warn).toHaveBeenCalledTimes(1);
+        });
+
+        it('for manjaro for 4.4.2', async () => {
+          jest.spyOn(console, 'warn').mockImplementation(() => void 0);
+
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: '4.4.2',
+            os: {
+              os: 'linux',
+              dist: 'ManjaroLinux',
+              release: '20.2',
+              id_like: ['arch'],
+            },
+          });
+          expect(await du.getDownloadUrl()).toBe(
+            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.2.tgz'
+          );
+          expect(console.warn).toHaveBeenCalledTimes(1);
+        });
+
+        it('for archstrike for 4.4.2', async () => {
+          jest.spyOn(console, 'warn').mockImplementation(() => void 0);
+
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: '4.4.2',
+            os: {
+              os: 'linux',
+              dist: 'ArchStrike',
+              release: 'rolling',
+              id_like: ['arch'],
+            },
+          });
+          expect(await du.getDownloadUrl()).toBe(
+            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.2.tgz'
+          );
+          expect(console.warn).toHaveBeenCalledTimes(1);
+        });
+      });
+
       it('fallback', async () => {
         jest.spyOn(console, 'warn').mockImplementation(() => void 0);
 
@@ -677,46 +740,6 @@ describe('MongoBinaryDownloadUrl', () => {
         expect(console.warn).toHaveBeenCalledTimes(2);
       });
 
-      it('for manjaro', async () => {
-        jest.spyOn(console, 'warn').mockImplementation(() => void 0);
-
-        const du = new MongoBinaryDownloadUrl({
-          platform: 'linux',
-          arch: 'x64',
-          version: '4.4.2',
-          os: {
-            os: 'linux',
-            dist: 'ManjaroLinux',
-            release: '20.2',
-            id_like: ['arch'],
-          },
-        });
-        expect(await du.getDownloadUrl()).toBe(
-          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.2.tgz'
-        );
-        expect(console.warn).toHaveBeenCalledTimes(1);
-      });
-
-      it('for arch', async () => {
-        jest.spyOn(console, 'warn').mockImplementation(() => void 0);
-
-        const du = new MongoBinaryDownloadUrl({
-          platform: 'linux',
-          arch: 'x64',
-          version: '4.4.2',
-          os: {
-            os: 'linux',
-            dist: 'Arch',
-            release: 'rolling',
-            id_like: ['arch'],
-          },
-        });
-        expect(await du.getDownloadUrl()).toBe(
-          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.2.tgz'
-        );
-        expect(console.warn).toHaveBeenCalledTimes(1);
-      });
-
       describe('for gentoo', () => {
         it('for gentoo 5.0.8', async () => {
           jest.spyOn(console, 'warn').mockImplementation(() => void 0);
@@ -755,26 +778,6 @@ describe('MongoBinaryDownloadUrl', () => {
           );
           expect(console.warn).toHaveBeenCalledTimes(1);
         });
-      });
-
-      it('for unpopular arch', async () => {
-        jest.spyOn(console, 'warn').mockImplementation(() => void 0);
-
-        const du = new MongoBinaryDownloadUrl({
-          platform: 'linux',
-          arch: 'x64',
-          version: '4.4.2',
-          os: {
-            os: 'linux',
-            dist: 'ArchStrike',
-            release: 'rolling',
-            id_like: ['arch'],
-          },
-        });
-        expect(await du.getDownloadUrl()).toBe(
-          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.2.tgz'
-        );
-        expect(console.warn).toHaveBeenCalledTimes(1);
       });
 
       describe('for elementary', () => {
@@ -1722,24 +1725,6 @@ describe('MongoBinaryDownloadUrl', () => {
       expect(console.warn).toHaveBeenCalledTimes(2);
       expect(du.getLegacyVersionString).toHaveBeenCalledTimes(1);
       expect(ret).toBe('');
-    });
-
-    it('should give a warning about "arch"', () => {
-      jest.spyOn(console, 'warn').mockImplementation(() => void 0);
-      const du = new MongoBinaryDownloadUrl({
-        platform: 'linux',
-        arch: 'x64',
-        version: '3.6.3',
-        os: {
-          os: 'linux',
-          dist: 'archlinux',
-          release: '0',
-          codename: 'archlinux',
-        },
-      });
-      const ret = du.getLinuxOSVersionString(du.os as LinuxOS);
-      expect(console.warn).toHaveBeenCalledTimes(1);
-      expect(ret).toBe('ubuntu1604');
     });
   });
 


### PR DESCRIPTION
Arch Linux is on OpenSSL 3 (instead of 1.1), like Ubuntu 22.04 (not like 20.04), so currently the `mongod` startup fails because of missing `libcrypto.so.1.1` (unless one has the `openssl-1.1` package installed for this or some other reason).

Tested by making this same change locally in the distributed `node_modules/mongodb-memory-server-core`.