### PR TITLE
fix: Fix binary download on debian testing/unstable

### DIFF
--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -289,7 +289,9 @@ export class MongoBinaryDownloadUrl implements MongoBinaryDownloadUrlOpts {
       throw new UnknownVersionError(this.version);
     }
 
-    if (release >= 11 || ['unstable', 'testing'].includes(os.release)) {
+    const isTesting = ['unstable', 'testing', ''].includes(os.release);
+
+    if (isTesting || release >= 11) {
       // Debian 11 is compatible with the binaries for debian 10
       // but does not have binaries for before 5.0.8
       // and only set to use "debian10" if the requested version is not a latest version
@@ -309,10 +311,10 @@ export class MongoBinaryDownloadUrl implements MongoBinaryDownloadUrlOpts {
       name += '71';
     }
 
-    if (release >= 10) {
+    if (isTesting || release >= 10) {
       if (semver.lt(coercedVersion, '4.2.1') && !testVersionIsLatest(this.version)) {
         throw new KnownVersionIncompatibilityError(
-          `Debian ${release}`,
+          `Debian ${release || os.release || os.codename}`,
           this.version,
           '>=4.2.1',
           'Mongodb does not provide binaries for versions before 4.2.1 for Debian 10+ and also cannot be mapped to a previous Debian release'

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -554,6 +554,22 @@ describe('MongoBinaryDownloadUrl', () => {
           );
         });
 
+        it('for debian testing/unstable', async () => {
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: '5.0.9',
+            os: {
+              os: 'linux',
+              dist: 'debian',
+              release: '',
+            },
+          });
+          expect(await du.getDownloadUrl()).toBe(
+            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian11-5.0.9.tgz'
+          );
+        });
+
         it('should throw a Error when the provided version could not be coerced [UnknownVersionError]', async () => {
           const du = new MongoBinaryDownloadUrl({
             platform: 'linux',
@@ -623,6 +639,29 @@ describe('MongoBinaryDownloadUrl', () => {
               os: 'linux',
               dist: 'debian',
               release: '11',
+            },
+          });
+
+          try {
+            await du.getDownloadUrl();
+            fail('Expected to throw a KnownVersionIncompatibilityError');
+          } catch (err) {
+            assertIsError(err);
+            expect(err).toBeInstanceOf(KnownVersionIncompatibilityError);
+            expect(err.message).toMatchSnapshot();
+          }
+        });
+
+        it('should throw a Error when requesting a version below 4.2.1 for debian testing [KnownVersionIncompatibilityError]', async () => {
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: '4.0.25',
+            os: {
+              os: 'linux',
+              dist: 'debian',
+              codename: 'trixie',
+              release: '',
             },
           });
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/__snapshots__/MongoBinaryDownloadUrl.test.ts.snap
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/__snapshots__/MongoBinaryDownloadUrl.test.ts.snap
@@ -10,6 +10,11 @@ exports[`MongoBinaryDownloadUrl getDownloadUrl() for linux for debian should thr
 Mongodb does not provide binaries for versions before 4.2.1 for Debian 10+ and also cannot be mapped to a previous Debian release"
 `;
 
+exports[`MongoBinaryDownloadUrl getDownloadUrl() for linux for debian should throw a Error when requesting a version below 4.2.1 for debian testing [KnownVersionIncompatibilityError] 1`] = `
+"Requested Version \\"4.0.25\\" is not available for \\"Debian trixie\\"! Available Versions: \\">=4.2.1\\"
+Mongodb does not provide binaries for versions before 4.2.1 for Debian 10+ and also cannot be mapped to a previous Debian release"
+`;
+
 exports[`MongoBinaryDownloadUrl getDownloadUrl() for linux for debian should throw a Error when the provided version could not be coerced [UnknownVersionError] 1`] = `"Could not corece VERSION to a semver version (version: \\"vvv\\")"`;
 
 exports[`MongoBinaryDownloadUrl getDownloadUrl() for linux for rhel should Error when ARM64 and rhel below 8 [KnownVersionIncompatibilityError] 1`] = `


### PR DESCRIPTION
VERSION_ID was removed. See
https://tracker.debian.org/news/1433360/accepted-base-files-13-source-into-unstable/

and a similar bug:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008735
