### PR TITLE
Add support for amazon linux 2023

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.event.inputs.git-ref }}
           fetch-depth: 5 # because this is an manual trigger, only fetch the latest 5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Load MongoDB binary cache
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Install node_modules

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Install & Build

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -415,8 +415,8 @@ export class MongoBinaryDownloadUrl implements MongoBinaryDownloadUrlOpts {
     let name = 'amazon';
     const release: number = parseInt(os.release, 10);
 
-    if (release >= 2 && release <= 3) {
-      name += '2';
+    if (release >= 2) {
+      name += release.toString();
     }
     // dont add anthing as fallback, because for "amazon 1", mongodb just uses "amazon"
 

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -1054,6 +1054,24 @@ describe('MongoBinaryDownloadUrl', () => {
             'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2-4.0.24.tgz'
           );
         });
+
+        it('should return a archive name for Amazon 2023', async () => {
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: '7.0.2',
+            os: {
+              os: 'linux',
+              dist: 'amzn',
+              release: '2023',
+              id_like: ['fedora'],
+            },
+          });
+
+          expect(await du.getDownloadUrl()).toBe(
+            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2023-7.0.2.tgz'
+          );
+        });
       });
 
       describe('for rhel', () => {


### PR DESCRIPTION
The os string in the download url for amazon linux 2023 should be "amazon2023"

<!--
## Make sure you have done these steps

- Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

## Related Issues
<!--Remove this part if not applicable-->

- fixes #825 
