### PR TITLE
fix(MongoBinaryDownloadUrl): support Debian 12 (Bookworm)

### DIFF
--- a/docs/guides/supported-systems.md
+++ b/docs/guides/supported-systems.md
@@ -71,8 +71,8 @@ See [this mongodb issue](https://jira.mongodb.org/browse/SERVER-62300).
 
 (uses mongodb's `debian` release)<br/>
 Lowest supported Distribution version is `71`<br/>
-Highest version is `11` (higher versions will be clamped to this value)<br/>
-Default version is `10` (when in `unstable` or `testing`, otherwise none)
+Highest version is `12` (higher versions will be clamped to this value)<br/>
+Default version is `12` (when in `unstable` or `testing`, otherwise none)
 
 ### Fedora
 

--- a/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
+++ b/packages/mongodb-memory-server-core/src/util/MongoBinaryDownloadUrl.ts
@@ -286,7 +286,9 @@ export class MongoBinaryDownloadUrl implements MongoBinaryDownloadUrlOpts {
     // see https://tracker.debian.org/news/1433360/accepted-base-files-13-source-into-unstable/
     const isTesting = ['unstable', 'testing', ''].includes(os.release);
 
-    if (isTesting || release >= 11) {
+    if (isTesting || release >= 12) {
+      name += '12';
+    } else if (release >= 11) {
       // Debian 11 is compatible with the binaries for debian 10
       // but does not have binaries for before 5.0.8
       // and only set to use "debian10" if the requested version is not a latest version
@@ -306,7 +308,16 @@ export class MongoBinaryDownloadUrl implements MongoBinaryDownloadUrlOpts {
       name += '71';
     }
 
-    if (isTesting || release >= 10) {
+    if (isTesting || release >= 12) {
+      if (semver.lt(coercedVersion, '7.0.3') && !testVersionIsLatest(this.version)) {
+        throw new KnownVersionIncompatibilityError(
+          `Debian ${release || os.release || os.codename}`,
+          this.version,
+          '>=7.0.3',
+          'Mongodb does not provide binaries for versions before 7.0.3 for Debian 12+ and also cannot be mapped to a previous Debian release'
+        );
+      }
+    } else if (release >= 10) {
       if (semver.lt(coercedVersion, '4.2.1') && !testVersionIsLatest(this.version)) {
         throw new KnownVersionIncompatibilityError(
           `Debian ${release || os.release || os.codename}`,

--- a/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/MongoBinaryDownloadUrl.test.ts
@@ -556,6 +556,22 @@ describe('MongoBinaryDownloadUrl', () => {
           );
         });
 
+        it('for debian 12 for 7.0.3', async () => {
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: '7.0.3',
+            os: {
+              os: 'linux',
+              dist: 'debian',
+              release: '12',
+            },
+          });
+          expect(await du.getDownloadUrl()).toBe(
+            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian12-7.0.3.tgz'
+          );
+        });
+
         it('should allow v5.0-latest', async () => {
           const du = new MongoBinaryDownloadUrl({
             platform: 'linux',
@@ -576,7 +592,7 @@ describe('MongoBinaryDownloadUrl', () => {
           const du = new MongoBinaryDownloadUrl({
             platform: 'linux',
             arch: 'x64',
-            version: '5.0.9',
+            version: '7.0.3',
             os: {
               os: 'linux',
               dist: 'debian',
@@ -584,7 +600,7 @@ describe('MongoBinaryDownloadUrl', () => {
             },
           });
           expect(await du.getDownloadUrl()).toBe(
-            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian11-5.0.9.tgz'
+            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian12-7.0.3.tgz'
           );
         });
 
@@ -670,11 +686,49 @@ describe('MongoBinaryDownloadUrl', () => {
           }
         });
 
-        it('should throw a Error when requesting a version below 4.2.1 for debian testing [KnownVersionIncompatibilityError]', async () => {
+        it('should throw an error when requesting a version below 7.0.3 for debian 12+ [#797] [KnownVersionIncompatibilityError]', async () => {
           const du = new MongoBinaryDownloadUrl({
             platform: 'linux',
             arch: 'x64',
-            version: '4.0.25',
+            version: '7.0.2',
+            os: {
+              os: 'linux',
+              dist: 'debian',
+              release: '12',
+            },
+          });
+
+          try {
+            await du.getDownloadUrl();
+            fail('Expected to throw a KnownVersionIncompatibilityError');
+          } catch (err) {
+            assertIsError(err);
+            expect(err).toBeInstanceOf(KnownVersionIncompatibilityError);
+            expect(err.message).toMatchSnapshot();
+          }
+        });
+
+        it('should not throw an error for v7.0-latest for debian 12', async () => {
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: 'v7.0-latest',
+            os: {
+              os: 'linux',
+              dist: 'debian',
+              release: '12',
+            },
+          });
+          expect(await du.getDownloadUrl()).toBe(
+            'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian12-v7.0-latest.tgz'
+          );
+        });
+
+        it('should throw a Error when requesting a version below 7.0.3 for debian testing [KnownVersionIncompatibilityError]', async () => {
+          const du = new MongoBinaryDownloadUrl({
+            platform: 'linux',
+            arch: 'x64',
+            version: '7.0.2',
             os: {
               os: 'linux',
               dist: 'debian',

--- a/packages/mongodb-memory-server-core/src/util/__tests__/__snapshots__/MongoBinaryDownloadUrl.test.ts.snap
+++ b/packages/mongodb-memory-server-core/src/util/__tests__/__snapshots__/MongoBinaryDownloadUrl.test.ts.snap
@@ -10,12 +10,17 @@ exports[`MongoBinaryDownloadUrl getDownloadUrl() for linux for debian should thr
 Mongodb does not provide binaries for versions before 4.2.1 for Debian 10+ and also cannot be mapped to a previous Debian release"
 `;
 
-exports[`MongoBinaryDownloadUrl getDownloadUrl() for linux for debian should throw a Error when requesting a version below 4.2.1 for debian testing [KnownVersionIncompatibilityError] 1`] = `
-"Requested Version \\"4.0.25\\" is not available for \\"Debian trixie\\"! Available Versions: \\">=4.2.1\\"
-Mongodb does not provide binaries for versions before 4.2.1 for Debian 10+ and also cannot be mapped to a previous Debian release"
+exports[`MongoBinaryDownloadUrl getDownloadUrl() for linux for debian should throw a Error when requesting a version below 7.0.3 for debian testing [KnownVersionIncompatibilityError] 1`] = `
+"Requested Version \\"7.0.2\\" is not available for \\"Debian trixie\\"! Available Versions: \\">=7.0.3\\"
+Mongodb does not provide binaries for versions before 7.0.3 for Debian 12+ and also cannot be mapped to a previous Debian release"
 `;
 
 exports[`MongoBinaryDownloadUrl getDownloadUrl() for linux for debian should throw a Error when the provided version could not be coerced [UnknownVersionError] 1`] = `"Could not coerce VERSION to a semver version (version: \\"vvv\\")"`;
+
+exports[`MongoBinaryDownloadUrl getDownloadUrl() for linux for debian should throw an error when requesting a version below 7.0.3 for debian 12+ [#797] [KnownVersionIncompatibilityError] 1`] = `
+"Requested Version \\"7.0.2\\" is not available for \\"Debian 12\\"! Available Versions: \\">=7.0.3\\"
+Mongodb does not provide binaries for versions before 7.0.3 for Debian 12+ and also cannot be mapped to a previous Debian release"
+`;
 
 exports[`MongoBinaryDownloadUrl getDownloadUrl() for linux for rhel should Error when ARM64 and rhel below 8 [KnownVersionIncompatibilityError] 1`] = `
 "Requested Version \\"4.4.2\\" is not available for \\"Rhel 7 arm64\\"! Available Versions: \\">=4.4.2\\"


### PR DESCRIPTION
Binaries for Debian 12 are available for MongoDB >= 7.0.3.

See https://jira.mongodb.org/browse/SERVER-77231

## Related Issues
<!--Remove this part if not applicable-->

- #797
